### PR TITLE
Frends.SFTP.DownloadFiles fixed issue #25 

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.2] - 2022-06-15
+### Fixed
+- Fixed issue with download failes when RenameDestinationFileDuringTransfer was enabled and destination file existed.
+- Added tests to test the issue.
+
 ## [1.0.1] - 2022-06-13
 ### Fixed
 - Fixed Source Operations removed source file when RenameSourceFileBeforeTransfer was enabled and transfer failed.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SingleFileTransfer.cs
@@ -207,8 +207,7 @@ internal class SingleFileTransfer
             "Downloading {0}destination file {1}",
             doRename ? "temporary " : string.Empty,
             Path.GetFileName(DestinationFileDuringTransfer));
-        var fileMode = removeExisting ? FileMode.Truncate : FileMode.Create;
-        using (var fs = File.Open(DestinationFileDuringTransfer, fileMode))
+        using (var fs = File.Open(DestinationFileDuringTransfer, FileMode.Create))
         {
             Client.DownloadFile(SourceFileDuringTransfer, fs);
         }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>1.0.1</Version>
+	  <Version>1.0.2</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
Fixed issue with download failed when RenameDestinationFileDuringTransfer was enabled and destination file existed.
Added more tests.