### PR TITLE
Fixed GetSourceFiles fetching dirtectories when using * as file mask

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.4] - 2022-06-30
+### Fixed
+- Fixed issue where '.' and '..' directories were also fetched when using '*' character as  source file mask.
+- Added check for GetSourceFiles so that only files are fetched and not directories.
+- Updated Microsoft.Extension.DependencyInjection library.
+
 ## [1.0.3] - 2022-06-29
 ### Fixed
 - Fixed issue with forward slash being added to the source directory.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
@@ -45,4 +45,23 @@ class ErrorTests : DownloadFilesTestBase
         var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
         Assert.That(ex.Message.StartsWith("SFTP transfer failed: Unable to establish the socket: No such host is known"));
     }
+
+    [Test]
+    public void DownloadFiles_TestWithSubDirNameAsFileMask()
+    {
+        var path = "/upload/test";
+        Helpers.CreateSubDirectory(path);
+        var source = new Source
+        {
+            Directory = "/upload",
+            FileName = "test",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing,
+        };
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
+        Assert.That(ex.Message.StartsWith("SFTP transfer failed: 1 Errors: No source files found from directory"));
+
+        Helpers.DeleteSubDirectory(path);
+    }
 }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
@@ -138,5 +138,25 @@ internal static class Helpers
         }
         return exists;
     }
+
+    internal static void CreateSubDirectory(string path)
+    {
+        using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
+        {
+            client.Connect();
+            client.CreateDirectory(path);
+            client.Disconnect();
+        }
+    }
+
+    internal static void DeleteSubDirectory(string path)
+    {
+        using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
+        {
+            client.Connect();
+            client.DeleteDirectory(path);
+            client.Disconnect();
+        }
+    }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -19,6 +19,24 @@ class TransferTests : DownloadFilesTestBase
         Assert.AreEqual(1, result.SuccessfulTransferCount);
     }
 
+    [Test]
+    public void DownloadFiles_TestDownloadWithFileMask()
+    {
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var source = new Source
+        {
+            Directory = _source.Directory,
+            FileName = "*",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing
+        };
+
+        var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
     [Test] 
     public void DownloadFiles_TestWithOperationLogDisabled()
     {

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -300,13 +300,17 @@ internal class FileTransporter
         // create List of FileItems from found files.
         foreach (var file in files)
         {
+            var name = file.Name;
+            if (file.Name.Equals(".") || file.Name.Equals("..")) continue;
+
+            if (file.IsDirectory) continue;
+
             if (Util.FileMatchesMask(Path.GetFileName(file.FullName), source.FileName))
             {
                 FileItem item = new FileItem(file);
                 _logger.NotifyInformation(_batchContext, $"FILE LIST {item.FullPath}");
                 fileItems.Add(item);
             }
-                    
         }
         return new Tuple<List<FileItem>, bool>(fileItems, true);
     }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>1.0.3</Version>
+	  <Version>1.0.4</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>
@@ -32,10 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-	<PackageReference Include="Newtonsoft.Json" Version="11.0.2">
-		<NoWarn>NU1605</NoWarn>
-	</PackageReference>
+	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 	<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	<PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="SSH.NET" Version="2020.0.2" />


### PR DESCRIPTION
- Fixed issue where '.' and '..' directories were also fetched when using '*' character as  source file mask.
- Added check for GetSourceFiles so that only files are fetched and not directories.
- Updated Microsoft.Extension.DependencyInjection library.
- Removed Newtonsoft.Json library because it's not used in the task