### PR TITLE
Fixes for Issue 41 SFTP.UploadFiles 

### DIFF
--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-# [2.0.0] - 2022-07-27
-###
-- [Breaking] Changed the implementation to work similar to Cobalt by moving the source file to local Temp folder before transfering to destination.
+# [2.0.0] - 2022-08-08
+### Fixed
+- [Breaking] Changed the implementation to work similar to Cobalt by moving the source file to local Temp folder before transferring to destination.
 - Fixed issue where PreserveModified caused exceptions because the method used wrong file path.
 - Fixed bug where source files were deleted if RenameSourceFileBeforeTransfer was enabled and SourceOperation.Move had directory that didn't exist.
 - Added logger usage in places where it was needed to make the operations log and error info more informative.

--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# [2.0.0] - 2022-07-27
+###
+- [Breaking] Changed the implementation to work similar to Cobalt by moving the source file to local Temp folder before transfering to destination.
+- Fixed issue where PreserveModified caused exceptions because the method used wrong file path.
+- Fixed bug where source files were deleted if RenameSourceFileBeforeTransfer was enabled and SourceOperation.Move had directory that didn't exist.
+- Added logger usage in places where it was needed to make the operations log and error info more informative.
+- Modified the logger usage that the logger.NotifyInformation is done after the action so it's easier to see where errors has occurred.
+
 ## [1.0.2] - 2022-06-08
 ### Fixed
 - Fixed Source Operations removed source file when RenameSourceFileBeforeTransfer was enabled and transfer failed.

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
@@ -12,9 +12,9 @@ internal static class Helpers
     /// <summary>
     /// Test credentials for docker server.
     /// </summary>
-    private static string _dockerAddress = "localhost";
-    private static string _dockerUsername = "foo";
-    private static string _dockerPassword = "pass";
+    readonly static string _dockerAddress = "localhost";
+    readonly static string _dockerUsername = "foo";
+    readonly static string _dockerPassword = "pass";
 
     internal static Connection GetSftpConnection()
     {
@@ -110,11 +110,6 @@ internal static class Helpers
         }
     }
 
-    internal static bool CheckFileExistsInSource(string fullPath)
-    {
-        return File.Exists(fullPath);
-    }
-
     internal static void DeleteDirectory(SftpClient client, string dir)
     {
             
@@ -123,13 +118,9 @@ internal static class Helpers
             if ((file.Name != ".") && (file.Name != ".."))
             {
                 if (file.IsDirectory)
-                {
                     DeleteDirectory(client, file.FullName);
-                }
                 else
-                {
                     client.DeleteFile(file.FullName);
-                }
             }
         }
         if (client.Exists(dir))

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
@@ -37,7 +37,7 @@ internal static class Helpers
     {
         var year = DateTime.Now.Year.ToString();
         var dir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../../TestData/testfolder_" + year);
-        if (Directory.Exists(year))
+        if (Directory.Exists(dir))
             Directory.Delete(dir, true);
     }
 
@@ -99,6 +99,22 @@ internal static class Helpers
         }
     }
 
+    internal static string GetLastWriteTimeFromDestination(string path)
+    {
+        using (var sftp = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
+        {
+            sftp.Connect();
+            var date = sftp.GetLastWriteTime(path);
+            sftp.Disconnect();
+            return date.ToString();
+        }
+    }
+
+    internal static bool CheckFileExistsInSource(string fullPath)
+    {
+        return File.Exists(fullPath);
+    }
+
     internal static void DeleteDirectory(SftpClient client, string dir)
     {
             
@@ -118,6 +134,21 @@ internal static class Helpers
         }
         if (client.Exists(dir))
             client.DeleteDirectory(dir);
+    }
+
+    internal static void UploadSingleTestFile(string dir, string pathToFile)
+    {
+        var path = dir + "/" + Path.GetFileName(pathToFile);
+        using (var sftp = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
+        {
+            sftp.Connect();
+            if (!sftp.Exists(dir)) sftp.CreateDirectory(dir);
+            using (var fs = File.Open(pathToFile, FileMode.Open))
+            {
+                sftp.UploadFile(fs, path);
+            }
+            sftp.Disconnect();
+        }
     }
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/MacroTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/MacroTests.cs
@@ -58,7 +58,7 @@ class MacroTests : UploadFilesTestBase
     {
         var destination = new Destination
         {
-            Directory = "upload/Upload/test%Year%",
+            Directory = "/upload/Upload/test%Year%",
             FileName = "",
             Action = DestinationAction.Error,
             FileNameEncoding = FileEncoding.UTF8,

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/PreserveModifiedTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/PreserveModifiedTests.cs
@@ -1,7 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
 using System.IO;
-using System.Collections.Generic;
 using System.Threading;
 using Frends.SFTP.UploadFiles.Definitions;
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/PreserveModifiedTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/PreserveModifiedTests.cs
@@ -1,0 +1,125 @@
+﻿using NUnit.Framework;
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading;
+using Frends.SFTP.UploadFiles.Definitions;
+
+namespace Frends.SFTP.UploadFiles.Tests;
+
+[TestFixture]
+class PreserveModifiedTests : UploadFilesTestBase
+{
+
+    private Destination destination;
+    private Options options;
+    private string sourcePath;
+    private string destFilePath;
+    private DateTime date;
+
+    [SetUp]
+    public void SetUp()
+    {
+        destination = new Destination
+        {
+            Directory = "/upload/Upload/destination",
+            Action = DestinationAction.Overwrite,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = true
+        };
+
+        options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = false,
+            RenameDestinationFileDuringTransfer = false,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = true,
+            OperationLog = true
+        };
+
+        sourcePath = Path.Combine(_workDir, _source.FileName);
+        destFilePath = destination.Directory + "/" + _source.FileName;
+        date = File.GetLastWriteTime(sourcePath);
+    }
+
+    [Test]
+    public void UploadFiles_TestPreserveLastModifiedWithoutRename()
+    {
+        var result = SFTP.UploadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(Helpers.CheckFileExistsInDestination(destFilePath));
+        Assert.AreEqual(date.ToString(), Helpers.GetLastWriteTimeFromDestination(destFilePath));
+    }
+
+    [Test]
+    public void UploadFiles_TestPreserveLastModifiedWithRename()
+    {
+        options.RenameSourceFileBeforeTransfer = true;
+        options.RenameDestinationFileDuringTransfer = true;
+
+        var result = SFTP.UploadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(Helpers.CheckFileExistsInDestination(destFilePath));
+        Assert.AreEqual(date.ToString(), Helpers.GetLastWriteTimeFromDestination(destFilePath));
+    }
+
+    [Test]
+    public void UploadFiles_TestPreserveLastModifiedWithSourceRename()
+    {
+        options.RenameSourceFileBeforeTransfer = true;
+        options.RenameDestinationFileDuringTransfer = false;
+
+        var result = SFTP.UploadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(Helpers.CheckFileExistsInDestination(destFilePath));
+        Assert.AreEqual(date.ToString(), Helpers.GetLastWriteTimeFromDestination(destFilePath));
+    }
+
+    [Test]
+    public void UploadFiles_TestPreserveLastModifiedWithDestinationRename()
+    {
+        options.RenameSourceFileBeforeTransfer = false;
+        options.RenameDestinationFileDuringTransfer = true;
+
+        var result = SFTP.UploadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(Helpers.CheckFileExistsInDestination(destFilePath));
+        Assert.AreEqual(date.ToString(), Helpers.GetLastWriteTimeFromDestination(destFilePath));
+    }
+
+    [Test]
+    public void UploadFiles_TestPreserveLastModifiedWithRenameAndDeleteSourceFile()
+    {
+        options.RenameSourceFileBeforeTransfer = true;
+        options.RenameDestinationFileDuringTransfer = true;
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile(Copy).txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Delete,
+        };
+
+        File.Copy(Path.Combine(_workDir, _source.FileName), Path.Combine(_workDir, source.FileName), true);
+
+        var result = SFTP.UploadFiles(source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        var destFilePath = destination.Directory + "/" + source.FileName;
+
+        Assert.IsTrue(Helpers.CheckFileExistsInDestination(destFilePath));
+        Assert.AreEqual(date.ToString(), Helpers.GetLastWriteTimeFromDestination(destFilePath));
+    }
+}
+

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TestData/SFTPUploadTestFile.txt
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TestData/SFTPUploadTestFile.txt
@@ -1,1 +1,1 @@
-This is a Test file
+This is another test file

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
@@ -236,7 +236,6 @@ class TransferTests : UploadFilesTestBase
 
         var result = SFTP.UploadFiles(_source, destination, _connection, options, _info, new CancellationToken());
         Assert.IsFalse(result.Success);
-        Assert.IsTrue(result.ActionSkipped);
         Assert.AreEqual(1, result.FailedTransferCount);
     }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
@@ -18,6 +18,22 @@ class TransferTests : UploadFilesTestBase
         Assert.AreEqual(1, result.SuccessfulTransferCount);
     }
 
+    [Test]
+    public void UploadFiles_TestUploadWithFileMaskEverything()
+    {
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "*",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(3, result.SuccessfulTransferCount);
+    }
+
     [Test] 
     public void UploadFiles_TestWithOperationLogDisabled()
     {
@@ -197,7 +213,7 @@ class TransferTests : UploadFilesTestBase
     }
 
     [Test]
-    public void UploadFile_TestSingleFileTransferWithError()
+    public void UploadFiles_TestSingleFileTransferWithError()
     {
         var options = new Options
         {
@@ -208,12 +224,20 @@ class TransferTests : UploadFilesTestBase
             PreserveLastModified = false,
             OperationLog = true
         };
-        var result = SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
 
-        result = SFTP.UploadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileName = "",
+            Action = DestinationAction.Error,
+        };
+
+        Helpers.UploadSingleTestFile(_destination.Directory, Path.Combine(_workDir, "SFTPUploadTestFile.txt"));
+
+        var result = SFTP.UploadFiles(_source, destination, _connection, options, _info, new CancellationToken());
         Assert.IsFalse(result.Success);
-        Assert.That(result.FailedTransferCount == 1);
+        Assert.IsTrue(result.ActionSkipped);
+        Assert.AreEqual(1, result.FailedTransferCount);
     }
 
     [Test]
@@ -232,6 +256,255 @@ class TransferTests : UploadFilesTestBase
         Assert.IsTrue(result.Success);
 
         Assert.IsTrue(File.Exists(Path.Combine(_workDir, _source.FileName)));
+    }
+
+    [Test]
+    public void UploadFiles_TestSourceOperationMoveWithRenameFilesDuringTransferDisabled()
+    {
+        var to = Path.Combine(_workDir, "destination");
+        Directory.CreateDirectory(to);
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = false,
+            RenameDestinationFileDuringTransfer = false,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = false,
+            OperationLog = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Move,
+            DirectoryToMoveAfterTransfer = to
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(File.Exists(Path.Combine(to, source.FileName)));
+        File.Move(Path.Combine(to, source.FileName), Path.Combine(_workDir, source.FileName));
+        Directory.Delete(to, true);
+    }
+
+    [Test]
+    public void UploadFiles_TestSourceOperationRenameWithRenameFilesDuringTransferDisabled()
+    {
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = false,
+            RenameDestinationFileDuringTransfer = false,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = false,
+            OperationLog = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Rename,
+            FileNameAfterTransfer = "uploaded_%SourceFileName%%SourceFileExtension%"
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(File.Exists(Path.Combine(_workDir, "uploaded_" + source.FileName)));
+        File.Move(Path.Combine(_workDir, "uploaded_" + source.FileName), Path.Combine(_workDir, source.FileName));
+    }
+
+    [Test]
+    public void UploadFiles_TestSourceOperationMoveWithRenameSourceAndDestinationFilesEnabled()
+    {
+        var to = Path.Combine(_workDir, "destination");
+        Directory.CreateDirectory(to);
+
+        var options = new Options
+        {
+            ThrowErrorOnFail = false,
+            RenameSourceFileBeforeTransfer = true,
+            RenameDestinationFileDuringTransfer = true,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = false,
+            OperationLog = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Move,
+            DirectoryToMoveAfterTransfer = to
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(File.Exists(Path.Combine(to, source.FileName)));
+        File.Move(Path.Combine(to, source.FileName), Path.Combine(_workDir, source.FileName));
+        Directory.Delete(to, true);
+    }                                                                                             
+
+    [Test]
+    public void UploadFiles_TestSourceOperationRenameWithRenameFilesDuringTransferWithRenameSourceAndDestinationFilesEnabled()
+    {
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = true,
+            RenameDestinationFileDuringTransfer = true,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = false,
+            OperationLog = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Rename,
+            FileNameAfterTransfer = "uploaded_%SourceFileName%%SourceFileExtension%"
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(File.Exists(Path.Combine(_workDir, "uploaded_" + source.FileName)));
+
+        File.Move(Path.Combine(_workDir, "uploaded_SFTPUploadTestFile.txt"), Path.Combine(_workDir, "SFTPUploadTestFile.txt"));
+    }
+
+    [Test]
+    public void UploadFiles_TestUploadWithOverwrite()
+    {
+        var destination = new Destination
+        {
+            Directory = "/upload/Upload",
+            FileName = "SFTPUploadTestFile.txt",
+            Action = DestinationAction.Overwrite,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = true
+        };
+
+        Helpers.UploadSingleTestFile(destination.Directory, Path.Combine(_workDir, _source.FileName));
+
+        var result = SFTP.UploadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(Helpers.CheckFileExistsInDestination(destination.Directory + "/" + _source.FileName));
+    }
+
+    [Test]
+    public void UploadFiles_TestUploadWithOnlyRenameSourceDuringTransferEnabled()
+    {
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = true,
+            RenameDestinationFileDuringTransfer = false,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = false,
+            OperationLog = true
+        };
+
+        var result = SFTP.UploadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(Helpers.CheckFileExistsInDestination(_destination.Directory + "/" + _source.FileName));
+    }
+
+    [Test]
+    public void UploadFiles_TestUploadWithOnlyRenameDestinationDuringTransferEnabled()
+    {
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = false,
+            RenameDestinationFileDuringTransfer = true,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = false,
+            OperationLog = true
+        };
+
+        var result = SFTP.UploadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(Helpers.CheckFileExistsInDestination(_destination.Directory + "/" + _source.FileName));
+    }
+
+    [Test]
+    public void UploadFiles_TestWithSourceMoveToNonExistingDirectoryShouldReturnUnsuccessfulTransfer()
+    {
+        var options = new Options
+        {
+            ThrowErrorOnFail = false,
+            RenameSourceFileBeforeTransfer = true,
+            RenameDestinationFileDuringTransfer = true,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = true,
+            OperationLog = true
+        };
+
+        var source = new Source
+        {
+            Directory = _source.Directory,
+            FileName = _source.FileName,
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Move,
+            DirectoryToMoveAfterTransfer = Path.Combine(_workDir, "uploaded"),
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+        Assert.IsFalse(result.Success);
+
+        Assert.IsTrue(File.Exists(Path.Combine(_workDir, _source.FileName)));
+    }
+
+    [Test]
+    public void UploadFiles_NoSourceFilesAndIgnoreShouldNotThrowException()
+    {
+        var source = new Source
+        {
+            Directory = _source.Directory,
+            FileName = "NonExistingFile.txt",
+            Action = SourceAction.Ignore,
+            Operation = SourceOperation.Delete
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.ActionSkipped);
+    }
+
+    [Test]
+    public void UploadFiles_NoSourceFilesAndInfoShouldNotThrowException()
+    {
+        var source = new Source
+        {
+            Directory = _source.Directory,
+            FileName = "NonExistingFile.txt",
+            Action = SourceAction.Info,
+            Operation = SourceOperation.Delete
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.ActionSkipped);
     }
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -38,6 +38,11 @@ internal class FileTransporter
     private string DestinationDirectoryWithMacrosExtended { get; set; }
 
     /// <summary>
+    /// Transfer state for SFTP Logger
+    /// </summary>
+    public TransferState State { get; set; }
+
+    /// <summary>
     /// Executes file transfers
     /// </summary>
     /// <param name="cancellationToken"></param>
@@ -57,6 +62,7 @@ internal class FileTransporter
             if (!success)
             {
                 userResultMessage = $"Directory '{_batchContext.Source.Directory}' doesn't exists.";
+                _logger.NotifyInformation(_batchContext, userResultMessage);
                 return FormFailedFileTransferResult(userResultMessage);
             }
 
@@ -96,6 +102,7 @@ internal class FileTransporter
                     {
                         try
                         {
+                            SetCurrentState(TransferState.Connection, "Checking server fingerprint.");
                             // If this check fails then SSH.NET will throw an SshConnectionException - with a message of "Key exchange negotiation failed".
                             client.HostKeyReceived += delegate (object sender, HostKeyEventArgs e)
                             {
@@ -132,6 +139,8 @@ internal class FileTransporter
 
                     client.BufferSize = _batchContext.Connection.BufferSize * 1024;
 
+                    SetCurrentState(TransferState.Connection, $"Connecting to {_batchContext.Connection.Address}:{_batchContext.Connection.Port} using SFTP.");
+
                     client.Connect();
 
                     if (!client.IsConnected)
@@ -140,6 +149,8 @@ internal class FileTransporter
                         return FormFailedFileTransferResult(userResultMessage);
                     }
 
+                    _logger.NotifyInformation(_batchContext, $"Connection has been stablished to target {_batchContext.Connection.Address}:{_batchContext.Connection.Port} using SFTP.");
+
                     // Check does the destination directory exists.
                     if (!client.Exists(DestinationDirectoryWithMacrosExtended))
                     {
@@ -147,24 +158,28 @@ internal class FileTransporter
                         {
                             try
                             {
+                                SetCurrentState(TransferState.CreateDestinationDirectories, $"Creating destination directory {DestinationDirectoryWithMacrosExtended}.");
                                 CreateDestinationDirectories(client, DestinationDirectoryWithMacrosExtended);
+                                _logger.NotifyInformation(_batchContext, $"DIRECTORY CREATE: Destination directory {DestinationDirectoryWithMacrosExtended} created.");
                             }
                             catch (Exception ex)
                             {
                                 userResultMessage = $"Error while creating destination directory '{DestinationDirectoryWithMacrosExtended}': {ex.Message}";
+                                _logger.NotifyError(_batchContext, userResultMessage, ex);
                                 return FormFailedFileTransferResult(userResultMessage);
                             }
                         }
                         else
                         {
                             userResultMessage = $"Destination directory '{DestinationDirectoryWithMacrosExtended}' was not found.";
+                            _logger.NotifyError(_batchContext, userResultMessage, new ArgumentException("No such directory."));
                             return FormFailedFileTransferResult(userResultMessage);
                         }
                     }
                     else
-                        client.ChangeDirectory(DestinationDirectoryWithMacrosExtended);
+                        // client.ChangeDirectory(DestinationDirectoryWithMacrosExtended);
 
-                    _batchContext.DestinationFiles = client.ListDirectory(".");
+                    _batchContext.DestinationFiles = client.ListDirectory(DestinationDirectoryWithMacrosExtended);
 
                     foreach (var file in files)
                     {
@@ -180,17 +195,24 @@ internal class FileTransporter
         catch (SshConnectionException ex)
         {
             userResultMessage = $"Error when establishing connection to the Server: {ex.Message}, {userResultMessage}";
+            _logger.NotifyError(_batchContext, userResultMessage, ex);
             return FormFailedFileTransferResult(userResultMessage);
         }
-        catch (SocketException)
+        catch (SocketException ex)
         {
             userResultMessage = $"Unable to establish the socket: No such host is known. {userResultMessage}";
+            _logger.NotifyError(_batchContext, userResultMessage, ex);
             return FormFailedFileTransferResult(userResultMessage);
         }
         catch (SshAuthenticationException ex)
         {
             userResultMessage = $"Authentication of SSH session failed: {ex.Message}, {userResultMessage}";
+            _logger.NotifyError(_batchContext, userResultMessage, ex);
             return FormFailedFileTransferResult(userResultMessage);
+        }
+        finally
+        {
+            CleanTempFiles(_batchContext);
         }
 
         return FormResultFromSingleTransferResults(_result);
@@ -306,10 +328,10 @@ internal class FileTransporter
         // create List of FileItems from found files.
         foreach (var file in files)
         {
-            if (Util.FileMatchesMask(Path.GetFileName(file), source.FileName))
+            if (Path.GetFileName(file).Equals(source.FileName) || Util.FileMatchesMask(Path.GetFileName(file), source.FileName))
             {
                 FileItem item = new FileItem(Path.GetFullPath(file));
-                _logger.NotifyInformation(_batchContext, $"FILE LIST {item.FullPath}");
+                _logger.NotifyInformation(_batchContext, $"FILE LIST {item.FullPath}.");
                 fileItems.Add(item);
             }
                     
@@ -320,7 +342,6 @@ internal class FileTransporter
 
     private static void CreateDestinationDirectories(SftpClient client, string path)
     {
-        var current = client.WorkingDirectory;
         // Consistent forward slashes
         foreach (string dir in path.Replace(@"\", "/").Split('/'))
         {
@@ -330,7 +351,6 @@ internal class FileTransporter
                 {
                     client.CreateDirectory(dir);
                     client.ChangeDirectory(dir);
-                    current = client.WorkingDirectory;
                 }
             }
         }
@@ -376,18 +396,10 @@ internal class FileTransporter
 
         _logger.LogBatchFinished(_batchContext, userResultMessage, success, actionSkipped);
 
-        var transferErrors = singleResults.Where(r => !r.Success).GroupBy(r => r.TransferredFile ?? "--unknown--")
+        var transferErrors = singleResults.Where(r => r.ErrorMessages.Any()).GroupBy(r => r.TransferredFile ?? "--unknown--")
                 .ToDictionary(rg => rg.Key, rg => (IList<string>)rg.SelectMany(r => r.ErrorMessages).ToList());
 
         var transferredFileResults = singleResults.Where(r => r.Success && !r.ActionSkipped).ToList();
-
-        var fileNames = from result in singleResults
-                        where result.Success
-                        select result.TransferredFile;
-
-        var filePaths = from result in singleResults
-                        where result.Success
-                        select result.TransferredFilePath;
 
         return new FileTransferResult {
             ActionSkipped = actionSkipped,
@@ -414,13 +426,12 @@ internal class FileTransporter
         var errorMessages = results.SelectMany(x => x.ErrorMessages).ToList();
         if (errorMessages.Any())
             userResultMessage = MessageJoin(userResultMessage,
-                string.Format("{0} Errors: {1}", errorMessages.Count, string.Join(", ", errorMessages)));
+                $"{errorMessages.Count} Errors: {string.Join(", \n", errorMessages)}.");
 
         var transferredFiles = results.Select(x => x.TransferredFile).Where(x => x != null).ToList();
         if (transferredFiles.Any())
             userResultMessage = MessageJoin(userResultMessage,
-                string.Format("{0} files transferred: {1}", transferredFiles.Count,
-                    string.Join(", ", transferredFiles)));
+                $"{transferredFiles.Count} files transferred: {string.Join(", ", transferredFiles)}.");
         else
             userResultMessage = MessageJoin(userResultMessage, "No files transferred.");
 
@@ -447,7 +458,7 @@ internal class FileTransporter
 
         if (context.Source.FilePaths == null)
             msg =
-                $"No source files found from directory '{source.Directory}' with file mask '{source.FileName}' for transfer '{transferName}'";
+                $"No source files found from directory '{SourceDirectoryWithMacrosExtended}' with file mask '{source.FileName}' for transfer '{transferName}'";
         else
             msg =
                 $"No source files found from FilePaths '{string.Join(", ", context.Source.FilePaths)}' for transfer '{transferName}'";
@@ -465,6 +476,25 @@ internal class FileTransporter
             default:
                 throw new Exception("Unknown operation in NoSourceOperation");
         }
+    }
+
+    private void CleanTempFiles(BatchContext context)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(context.TempWorkDir) && Directory.Exists(context.TempWorkDir))
+                Directory.Delete(context.TempWorkDir, true);
+        }
+        catch (Exception ex)
+        {
+            _logger.NotifyError(context, "Temp workdir cleanup failed.", ex);
+        }
+    }
+
+    private void SetCurrentState(TransferState state, string msg)
+    {
+        State = state;
+        _logger.NotifyTrace($"{state}: {msg}");
     }
 
     #endregion

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -428,7 +428,7 @@ internal class FileTransporter
             userResultMessage = MessageJoin(userResultMessage,
                 $"{errorMessages.Count} Errors: {string.Join(", \n", errorMessages)}.");
 
-        var transferredFiles = results.Select(x => x.TransferredFile).Where(x => x != null).ToList();
+        var transferredFiles = results.Where(x => x.Success).Select(x => x.TransferredFile).ToList();
         if (transferredFiles.Any())
             userResultMessage = MessageJoin(userResultMessage,
                 $"{transferredFiles.Count} files transferred: {string.Join(", ", transferredFiles)}.");

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -22,14 +22,19 @@ internal class SingleFileTransfer
         DestinationFileWithMacrosExpanded = Path.Combine(destinationDirectory, renamingPolicy.CreateRemoteFileName(
                 file.Name,
                 context.Destination.FileName));
+        if (destinationDirectory.Contains('/')) DestinationFileWithMacrosExpanded = DestinationFileWithMacrosExpanded.Replace("\\", "/"); 
+        WorkFileInfo = new WorkFileInfo(file.Name, Path.GetFileName(DestinationFileWithMacrosExpanded), BatchContext.TempWorkDir);
 
         _result = new SingleFileTransferResult { Success = true };
     }
 
     public DateTime FileTransferStartTime { get; set; }
 
+    public WorkFileInfo WorkFileInfo { get; set; } 
+
     public SftpClient Client { get; set; }
     public FileItem SourceFile { get; set; }
+    public FileItem DestinationFile { get; set; }
     public string DestinationFileWithMacrosExpanded { get; set; }
     private string SourceFileDuringTransfer { get; set; }
     public string DestinationFileDuringTransfer { get; set; }
@@ -46,13 +51,14 @@ internal class SingleFileTransfer
         {
             _result.TransferredFile = SourceFile.Name;
             _result.TransferredFilePath = SourceFile.FullPath;
-            if (BatchContext.Options.RenameSourceFileBeforeTransfer)
-                SourceFileDuringTransfer = RenameSourceFile();
-            else 
-                SourceFileDuringTransfer = SourceFile.FullPath;
 
-            if (DestinationFileExists(Path.GetFileName(DestinationFileWithMacrosExpanded)))
+            GetSourceFile();
+
+            ExecuteSourceOperationMoveOrRename();
+
+            if (DestinationFileExists(DestinationFileWithMacrosExpanded))
             {
+                DestinationFile = new FileItem(Client.Get(DestinationFileWithMacrosExpanded));
                 switch (BatchContext.Destination.Action)
                 {
                     case DestinationAction.Append:
@@ -65,13 +71,12 @@ internal class SingleFileTransfer
                         throw new DestinationFileExistsException(Path.GetFileName(DestinationFileWithMacrosExpanded));
                 }
             }
-            else
-                PutDestinationFile();
+            else PutDestinationFile();
 
-            if (BatchContext.Options.PreserveLastModified)
-                RestoreModified();
+            if (BatchContext.Options.PreserveLastModified) RestoreModified();
 
-            ExecuteSourceOperation();
+            ExecuteSourceOperationNothingOrDelete();
+
             _logger.LogTransferSuccess(this, BatchContext);
             CleanUpFiles();
         }
@@ -83,37 +88,52 @@ internal class SingleFileTransfer
             var destinationFileRestoreMessage = RestoreDestinationFileAfterErrorIfItWasRenamed(Client);
             if (!string.IsNullOrEmpty(destinationFileRestoreMessage))
                 HandleTransferError(ex, destinationFileRestoreMessage);
-
         }
         return _result;
     }
 
-    private bool DestinationFileExists(string fileName)
+    private void GetSourceFile()
     {
-        Trace(
-            TransferState.CheckIfDestinationFileExists,
-            "Checking if destination file {0} exists",
-            SourceFile.NameWithMacrosExtended);
-        return Client.Exists(fileName);
+        if (BatchContext.Options.RenameSourceFileBeforeTransfer)
+            RenameSourceFile();
+        else
+            SourceFileDuringTransfer = SourceFile.FullPath;
+
+        SetCurrentState(TransferState.GetFile, $"Downloading source file {Path.GetFileName(SourceFileDuringTransfer)} to local temp file {WorkFileInfo.WorkFilePath}");
+        File.Copy(SourceFileDuringTransfer, Path.Combine(WorkFileInfo.WorkFileDir, Path.GetFileName(SourceFileDuringTransfer)));
+        _logger.NotifyInformation(BatchContext, $"FILE COPY: {SourceFileDuringTransfer} to {WorkFileInfo.WorkFilePath}");
     }
 
-    private string RenameSourceFile()
+    private bool DestinationFileExists(string path)
     {
+        SetCurrentState(
+            TransferState.CheckIfDestinationFileExists,
+            $"Checking if destination file {path} exists");
+        var exists = Client.Exists(path);
+        _logger.NotifyInformation(BatchContext, $"FILE EXISTS {path}: {exists}.");
+        return exists;
+    }
+
+    private void RenameSourceFile()
+    {
+        if (!string.IsNullOrEmpty(SourceFileDuringTransfer))
+        {
+            File.Move(SourceFileDuringTransfer, SourceFile.FullPath);
+            return;
+        }
+
         var uniqueFileName = Util.CreateUniqueFileName();
-        var workdir = (!string.IsNullOrEmpty(BatchContext.Info.WorkDir) ? BatchContext.Info.WorkDir : Path.GetDirectoryName(SourceFile.FullPath));
-        var renamedFile = Path.Combine(workdir, uniqueFileName);
+        var directory = Path.GetDirectoryName(SourceFile.FullPath);
+        SourceFileDuringTransfer = Path.Combine(directory, uniqueFileName);
 
-        Trace(TransferState.RenameSourceFileBeforeTransfer, "Renaming source file {0} to temporary file name {1} before transfer", SourceFile.Name, uniqueFileName);
-        File.Move(SourceFile.FullPath, renamedFile);
-
-        return renamedFile;
+        SetCurrentState(TransferState.RenameSourceFileBeforeTransfer, $"Renaming source file {SourceFile.Name} to temporary file name {uniqueFileName} before transfer");
+        File.Move(SourceFile.FullPath, SourceFileDuringTransfer);
+        _logger.NotifyInformation(BatchContext, $"FILE RENAME: Source file {SourceFile.Name} renamed to target {Path.GetFileName(SourceFileDuringTransfer)}.");
     }
 
     private void AppendDestinationFile()
     {
-        var fullPath = SourceFile.FullPath;
-        if (!string.IsNullOrEmpty(SourceFileDuringTransfer))
-            fullPath = SourceFileDuringTransfer;
+        var filePath = Path.Combine(WorkFileInfo.WorkFileDir, Path.GetFileName(SourceFileDuringTransfer));
         Encoding encoding;
         try
         {
@@ -127,7 +147,7 @@ internal class SingleFileTransfer
         if (BatchContext.Options.RenameDestinationFileDuringTransfer)
             RenameDestinationFile();
 
-        Append(GetSourceFileContent(fullPath, encoding), encoding);
+        Append(GetSourceFileContent(filePath, encoding), encoding);
 
         if (BatchContext.Options.RenameDestinationFileDuringTransfer)
             RenameDestinationFile();
@@ -137,39 +157,39 @@ internal class SingleFileTransfer
     {
         if (!string.IsNullOrEmpty(DestinationFileDuringTransfer))
         {
-            Client.RenameFile(DestinationFileDuringTransfer, Path.GetFileName(DestinationFileWithMacrosExpanded));
-            return;
+            SetCurrentState(TransferState.RenameDestinationFile, $"Renaming temporary destination file {Path.GetFileName(DestinationFileDuringTransfer)} to target file {DestinationFile.Name}.");
+            Client.RenameFile(DestinationFileDuringTransfer, DestinationFileWithMacrosExpanded);
+            _logger.NotifyInformation(BatchContext, $"FILE RENAME: Temporary destination file {Path.GetFileName(DestinationFileDuringTransfer)} renamed to target {DestinationFile.Name}.");
         }
-
-        DestinationFileDuringTransfer = Util.CreateUniqueFileName();
-        Trace(TransferState.RenameDestinationFile, "Renaming destination file {0} to temporary file name {1} during transfer", Path.GetFileName(DestinationFileWithMacrosExpanded), DestinationFileDuringTransfer);
-        Client.RenameFile(Path.GetFileName(DestinationFileWithMacrosExpanded), DestinationFileDuringTransfer);
-        return;
+        else
+        {
+            var path = Path.Combine(Path.GetDirectoryName(DestinationFileWithMacrosExpanded), Util.CreateUniqueFileName());
+            DestinationFileDuringTransfer = (DestinationFileWithMacrosExpanded.Contains("/")) ? path.Replace("\\", "/") : path;
+            SetCurrentState(TransferState.RenameDestinationFile, $"Renaming destination file {Path.GetFileName(DestinationFileWithMacrosExpanded)} to temporary file name {Path.GetFileName(DestinationFileDuringTransfer)} during transfer");
+            Client.RenameFile(DestinationFileWithMacrosExpanded, DestinationFileDuringTransfer);
+        }  
     }
 
     private void Append(string[] content, Encoding encoding)
     {
-        Trace(
+        SetCurrentState(
             TransferState.AppendToDestinationFile,
-            "Appending file {0} to existing file {1}",
-            SourceFile.Name,
-            Path.GetFileName(DestinationFileWithMacrosExpanded));
-
-        var path = Client.WorkingDirectory;
+            $"Appending file {SourceFile.Name} to existing file {DestinationFile.Name}");
 
         // If destination rename during transfer is enabled, use that instead 
-        path = (!string.IsNullOrEmpty(DestinationFileDuringTransfer)) 
-            ? path + "/" + DestinationFileDuringTransfer
-            : path + "/" + DestinationFileWithMacrosExpanded;
+        var path = (!string.IsNullOrEmpty(DestinationFileDuringTransfer)) 
+            ? DestinationFileDuringTransfer
+            : DestinationFileWithMacrosExpanded;
 
         Client.AppendAllLines(path, content, encoding);
+        _logger.NotifyInformation(BatchContext, $"FILE APPEND: Source file appended to target {DestinationFile.Name}.");
     }
 
-    private static string[] GetSourceFileContent(string fullPath, Encoding encoding)
+    private static string[] GetSourceFileContent(string filePath, Encoding encoding)
     {
         var result = new List<string>();
         result.Add("\n");
-        var content = File.ReadAllLines(fullPath, encoding);
+        var content = File.ReadAllLines(filePath, encoding);
         foreach (var line in content)
             result.Add(line);
 
@@ -185,38 +205,38 @@ internal class SingleFileTransfer
     {
         var doRename = BatchContext.Options.RenameDestinationFileDuringTransfer;
 
-        DestinationFileDuringTransfer = doRename ? Util.CreateUniqueFileName() : Path.GetFileName(DestinationFileWithMacrosExpanded);
-        Trace(
-            TransferState.PutFile,
-            "Uploading {0}destination file {1}",
-            doRename ? "temporary " : string.Empty,
-            DestinationFileDuringTransfer);
+        DestinationFileDuringTransfer = doRename ? Path.Combine(Path.GetDirectoryName(DestinationFileWithMacrosExpanded), Util.CreateUniqueFileName()): DestinationFileWithMacrosExpanded;
+        if (DestinationFileWithMacrosExpanded.Contains('/')) DestinationFileDuringTransfer = DestinationFileDuringTransfer.Replace("\\", "/");
 
-        using (var fs = File.OpenRead(SourceFileDuringTransfer))
+        var helper = doRename ? "temporary " : string.Empty;
+        SetCurrentState(
+            TransferState.PutFile,
+            $"Uploading {helper}destination file { Path.GetFileName(DestinationFileDuringTransfer)} to destination {DestinationFileWithMacrosExpanded}.");
+
+        using (var fs = new FileStream(Path.Combine(WorkFileInfo.WorkFileDir, Path.GetFileName(SourceFileDuringTransfer)), FileMode.Open))
         {
             Client.UploadFile(fs, DestinationFileDuringTransfer, removeExisting);
+            _logger.NotifyInformation(BatchContext, $"FILE PUT: Source file {SourceFile.FullPath} uploaded to target {DestinationFileWithMacrosExpanded}.");
         }
 
         if (!doRename) return;
 
         if (removeExisting)
         {
-            Trace(
+            SetCurrentState(
                 TransferState.DeleteDestinationFile,
-                "Deleting destination file {0} that is to be overwritten",
-                Path.GetFileName(DestinationFileWithMacrosExpanded));
+                $"Deleting destination file {Path.GetFileName(DestinationFileWithMacrosExpanded)} that is to be overwritten");
 
             Client.DeleteFile(DestinationFileWithMacrosExpanded);
+            _logger.NotifyInformation(BatchContext, $"FILE DELETE: Destination file {Path.GetFileName(DestinationFileWithMacrosExpanded)} deleted.");
         }
 
-        Trace(
+        SetCurrentState(
             TransferState.RenameDestinationFile,
-            "Renaming temporary destination file {0} to target file {1}",
-            DestinationFileDuringTransfer,
-            Path.GetFileName(DestinationFileWithMacrosExpanded));
+            $"Renaming temporary destination file {Path.GetFileName(DestinationFileDuringTransfer)} to target file {Path.GetFileName(DestinationFileWithMacrosExpanded)}");
 
-        Client.RenameFile(DestinationFileDuringTransfer, Path.GetFileName(DestinationFileWithMacrosExpanded));
-
+        Client.RenameFile(DestinationFileDuringTransfer, DestinationFileWithMacrosExpanded);
+        _logger.NotifyInformation(BatchContext, $"FILE RENAME: Temporary destination file {Path.GetFileName(DestinationFileDuringTransfer)} renamed to target {Path.GetFileName(DestinationFileWithMacrosExpanded)}.");
     }
 
     /// <summary>
@@ -224,8 +244,12 @@ internal class SingleFileTransfer
     /// </summary>
     private void RestoreModified()
     {
+        var date = SourceFile.Modified;
+        SetCurrentState(
+            TransferState.RestoreModified,
+            $"Restoring the modified datetime of transferred file {Path.GetFileName(DestinationFileWithMacrosExpanded)}");
         var fileAttributes = Client.GetAttributes(DestinationFileWithMacrosExpanded);
-        fileAttributes.LastWriteTime = SourceFile.Modified;
+        fileAttributes.LastWriteTime = date;
         Client.SetAttributes(DestinationFileWithMacrosExpanded, fileAttributes);
         return;
     }
@@ -251,44 +275,75 @@ internal class SingleFileTransfer
         }
     }
 
-    private void ExecuteSourceOperation()
+    private void ExecuteSourceOperationMoveOrRename()
+    {
+        var filePath = string.IsNullOrEmpty(SourceFileDuringTransfer) ? SourceFile.FullPath : SourceFileDuringTransfer;
+
+        if (BatchContext.Source.Operation == SourceOperation.Move)
+        {
+            var moveToPath = _renamingPolicy.ExpandDirectoryForMacros(BatchContext.Source.DirectoryToMoveAfterTransfer);
+            SetCurrentState(TransferState.SourceOperationMove, $"Moving source file {SourceFile.FullPath} to {moveToPath}");
+            if (!Directory.Exists(moveToPath))
+            {
+                var msg = $"Operation failed: Source file {SourceFile.Name} couldn't be moved to given directory {moveToPath} because the directory didn't exist.";
+                _logger.NotifyError(BatchContext, msg, new ArgumentException("Failure in moving the source file."));
+                _result.ErrorMessages.Add($"Failure in source operation: {msg}");
+            }
+
+            var destFileName = moveToPath.Contains('/')
+                ? moveToPath + "/" + SourceFile.Name
+                : Path.Combine(moveToPath, SourceFile.Name);
+
+            try { File.Move(filePath, destFileName); }
+            catch (Exception ex) { throw new Exception($"Failure in source operation: {ex.Message}"); }
+
+            _logger.NotifyInformation(BatchContext, $"FILE MOVE: Source file {SourceFileDuringTransfer} moved to target {destFileName}.");
+            SourceFile = new FileItem(destFileName);
+
+            if (SourceFile.FullPath == null)
+                _logger.NotifyInformation(BatchContext, "Source end point returned null as the moved file. It should return the name of the moved file.");
+        }
+        else if (BatchContext.Source.Operation == SourceOperation.Rename)
+        {
+            var renameToPath = Path.Combine(Path.GetDirectoryName(SourceFile.FullPath), _renamingPolicy.CreateRemoteFileNameForRename(SourceFile.FullPath, BatchContext.Source.FileNameAfterTransfer));
+            SetCurrentState(TransferState.SourceOperationRename, $"Renaming source file {Path.GetFileName(SourceFile.FullPath)} to {renameToPath}");
+            
+            File.Move(filePath, renameToPath);
+            _logger.NotifyInformation(BatchContext, $"FILE RENAME: Source file {SourceFileDuringTransfer} renamed to target {renameToPath}.");
+
+            SourceFile = new FileItem(renameToPath);
+            if (!File.Exists(renameToPath))
+            {
+                var msg = $"Operation failed: Source file {SourceFile.Name} couldn't be renamed to given name {Path.GetFileName(renameToPath)}";
+                _logger.NotifyError(BatchContext, msg, new ArgumentException("Failure in renaming source file."));
+                _result.ErrorMessages.Add($"Failure in source operation: {msg}");
+            }
+
+            if (SourceFile.FullPath == null)
+                _logger.NotifyInformation(BatchContext, "Source end point returned null as the renamed file. It should return the name of the renamed file.");
+        }
+    }
+
+    private void ExecuteSourceOperationNothingOrDelete()
     {
         var filePath = string.IsNullOrEmpty(SourceFileDuringTransfer) ? SourceFile.FullPath : SourceFileDuringTransfer;
         switch (BatchContext.Source.Operation)
         {
-            case SourceOperation.Move:
-                var moveToPath = _renamingPolicy.CreateRemoteFilePathForMove(_renamingPolicy.ExpandDirectoryForMacros(BatchContext.Source.DirectoryToMoveAfterTransfer), SourceFile.FullPath);
-                Trace(TransferState.SourceOperationMove, "Moving source file {0} to {1}", SourceFile.FullPath, moveToPath);
-                File.Move(filePath, moveToPath);
-
-                if (SourceFile.FullPath == null)
-                    _logger.NotifyInformation(BatchContext, "Source end point returned null as the moved file. It should return the name of the moved file.");
-                break;
-
-            case SourceOperation.Rename:
-                var renameToPath = Path.Combine(Path.GetDirectoryName(SourceFile.FullPath), _renamingPolicy.CreateRemoteFileNameForRename(SourceFile.FullPath, BatchContext.Source.FileNameAfterTransfer));
-                Trace(TransferState.SourceOperationRename, "Renaming source file {0} to {1}", SourceFile.FullPath, renameToPath);
-                File.Move(filePath, renameToPath);
-
-                if (SourceFile.FullPath == null)
-                    _logger.NotifyInformation(BatchContext, "Source end point returned null as the renamed file. It should return the name of the renamed file.");
-                break;
-
             case SourceOperation.Delete:
-                Trace(TransferState.SourceOperationDelete, "Deleting source file {0} after transfer", Path.GetFileName(SourceFile.FullPath));
+                SetCurrentState(TransferState.SourceOperationDelete, $"Deleting source file {Path.GetFileName(SourceFile.FullPath)} after transfer");
                 File.Delete(filePath);
+                _logger.NotifyInformation(BatchContext, $"FILE DELETE: Source file {filePath} deleted.");
                 break;
 
             case SourceOperation.Nothing:
                 if (BatchContext.Options.RenameSourceFileBeforeTransfer)
                 {
-                    Trace(
+                    SetCurrentState(
                         TransferState.RestoreSourceFile,
-                        "Restoring source file from {0} to the original name {1}",
-                        Path.GetFileName(SourceFileDuringTransfer),
-                        Path.GetFileName(SourceFile.FullPath));
+                        $"Restoring source file from {Path.GetFileName(SourceFileDuringTransfer)} to the original name {Path.GetFileName(SourceFile.FullPath)}");
 
                     File.Move(filePath, SourceFile.FullPath);
+                    _logger.NotifyInformation(BatchContext, $"FILE RENAME: Temporary file {SourceFileDuringTransfer} restored to target {SourceFile.FullPath}.");
                 }
                 break;
         }
@@ -296,23 +351,30 @@ internal class SingleFileTransfer
 
     private void CleanUpFiles()
     {
-        if (BatchContext.Options.RenameSourceFileBeforeTransfer && !Path.GetFileName(SourceFileDuringTransfer).Equals(SourceFile.FullPath))
+        SetCurrentState(TransferState.CleanUpFiles, $"Checking if temporary source file {WorkFileInfo.WorkFilePath} exists.");
+        var exists = !string.IsNullOrEmpty(WorkFileInfo.WorkFilePath) && File.Exists(WorkFileInfo.WorkFilePath);
+        _logger.NotifyInformation(BatchContext, $"FILE EXISTS {WorkFileInfo.WorkFilePath}: {exists}");
+        if (exists)
         {
-            Trace(TransferState.CleanUpFiles, "Removing temporary file {0}", Path.GetFileName(SourceFileDuringTransfer));
-            TryToRemoveLocalTempFile(SourceFileDuringTransfer);
+            SetCurrentState(TransferState.CleanUpFiles, $"Removing temporary source file {WorkFileInfo.WorkFilePath}.");
+            TryToRemoveLocalTempFile(WorkFileInfo.WorkFilePath);
         }
-                
-        if (BatchContext.Options.RenameDestinationFileDuringTransfer && !Path.GetFileName(DestinationFileDuringTransfer).Equals(Path.GetFileName(DestinationFileWithMacrosExpanded)))
-        {
-            Trace(TransferState.CleanUpFiles, "Removing temporary file {0}", Path.GetFileName(DestinationFileDuringTransfer));
-            TryToRemoveDestinationTempFile();
-        }
+
+        exists = !string.IsNullOrEmpty(DestinationFileDuringTransfer) && File.Exists(DestinationFileDuringTransfer) && BatchContext.Options.RenameDestinationFileDuringTransfer;
+        if (!exists) return;
+        SetCurrentState(TransferState.CleanUpFiles, $"Checking if temporary destination file {DestinationFileDuringTransfer} exists.");
+        _logger.NotifyInformation(BatchContext, $"FILE EXISTS {DestinationFileDuringTransfer}: {exists}");
+        SetCurrentState(TransferState.CleanUpFiles, $"Removing temporary destination file {WorkFileInfo.WorkFilePath}.");
+        TryToRemoveDestinationTempFile();
     }
 
     private void HandleTransferError(Exception exception, string sourceFileRestoreMessage)
     {
         _result.Success = false; // the routine instance should be marked as failed if even one transfer fails
-        var errorMessage = string.Format("Failure in {0}: File '{1}' could not be transferred to '{2}'. Error: {3}", State, SourceFile.Name, Path.GetDirectoryName(DestinationFileWithMacrosExpanded), exception.Message);
+        var directory = (DestinationFileWithMacrosExpanded.Contains('/'))
+            ? Path.GetDirectoryName(DestinationFileWithMacrosExpanded).Replace("\\", "/")
+            : Path.GetDirectoryName(DestinationFileWithMacrosExpanded);
+        var errorMessage = $"Failure in {State}: File '{SourceFile.Name}' could not be transferred to '{directory}'. Error: {exception.Message}";
         if (!string.IsNullOrEmpty(sourceFileRestoreMessage)) errorMessage += " " + sourceFileRestoreMessage;
 
         _result.ErrorMessages.Add(errorMessage);
@@ -333,36 +395,39 @@ internal class SingleFileTransfer
         {
             if (DestinationFileExists(Path.GetFileName(DestinationFileDuringTransfer)))
             {
-                Trace(TransferState.RemoveTemporaryDestinationFile, "Removing temporary destination file {0}", DestinationFileDuringTransfer);
+                SetCurrentState(TransferState.RemoveTemporaryDestinationFile, $"Removing temporary destination file {DestinationFileDuringTransfer}");
                 Client.DeleteFile(DestinationFileDuringTransfer);
+                _logger.NotifyInformation(BatchContext, $"FILE DELETE: Temporary destination file {DestinationFileDuringTransfer} removed.");
             }
         }
         catch (Exception ex)
         {
-            _logger.NotifyError(BatchContext, string.Format("Could not clean up temporary destination file '{0}': {1}", DestinationFileDuringTransfer, ex.Message), ex);
+            _logger.NotifyError(BatchContext, $"Could not clean up temporary destination file '{DestinationFileDuringTransfer}': {ex.Message}", ex);
         }
     }
 
-    private void TryToRemoveLocalTempFile(string fileName)
+    private void TryToRemoveLocalTempFile(string filePath)
     {
         try
         {
-            if (FileDefinedAndExists(fileName))
+            if (FileDefinedAndExists(filePath))
             {
-                if ((File.GetAttributes(fileName) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
-                    File.SetAttributes(fileName, FileAttributes.Normal); // Clear flags so readonly doesn't cause any problems CO-469
-                File.Delete(fileName);
+                if ((File.GetAttributes(filePath) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                    File.SetAttributes(filePath, FileAttributes.Normal); 
+
+                File.Delete(filePath);
+                _logger.NotifyInformation(BatchContext, $"FILE DELETE: Temporary source file {filePath} removed.");
             }
         }
         catch (Exception e)
         {
-            _logger.NotifyError(BatchContext, string.Format("Could not clean up local file '{0}'", fileName), e);
+            _logger.NotifyError(BatchContext, $"Could not clean up local file '{filePath}'", e);
         }
     }
 
-    private static bool FileDefinedAndExists(string filename)
+    private static bool FileDefinedAndExists(string path)
     {
-        return !string.IsNullOrEmpty(filename) && File.Exists(filename);
+        return !string.IsNullOrEmpty(path) && File.Exists(path);
     }
 
     private string RestoreSourceFileAfterErrorIfItWasRenamed()
@@ -381,14 +446,10 @@ internal class SingleFileTransfer
             }
             catch (Exception ex)
             {
-                var message = string.Format(
-                    "Could not restore original source file '{0}' from temporary file '{1}'. Error: {2}.",
-                    Path.GetFileName(SourceFile.FullPath),
-                    Path.GetFileName(SourceFileDuringTransfer),
-                    ex.Message);
+                var message = $"Could not restore original source file '{Path.GetFileName(SourceFile.FullPath)}' from temporary file '{Path.GetFileName(SourceFileDuringTransfer)}'. Error: {ex.Message}.";
 
                 _logger.NotifyError(BatchContext, message, ex);
-                return string.Format("[{0}]", message);
+                return $"[{message}]";
             }
         }
 
@@ -403,19 +464,15 @@ internal class SingleFileTransfer
             {
                 if (BatchContext.Options.RenameDestinationFileDuringTransfer)
                 {
-                    client.RenameFile(Path.GetFileName(DestinationFileDuringTransfer), Path.GetFileName(DestinationFileWithMacrosExpanded));
+                    client.RenameFile(DestinationFileDuringTransfer, DestinationFileWithMacrosExpanded);
                     return string.Empty;
                 }
             } catch (Exception ex)
             {
-                var message = string.Format(
-                    "Could not restore original destination file '{0}' from temporary file '{1}'. Error: {2}.",
-                    Path.GetFileName(DestinationFileWithMacrosExpanded),
-                    Path.GetFileName(DestinationFileDuringTransfer),
-                    ex.Message);
+                var message = $"Could not restore original destination file '{Path.GetFileName(DestinationFileWithMacrosExpanded)}' from temporary file '{Path.GetFileName(DestinationFileDuringTransfer)}'. Error: {ex.Message}.";
 
                 _logger.NotifyError(BatchContext, message, ex);
-                return string.Format("[{0}]", message);
+                return $"[{message}]";
             }
         }
 
@@ -424,28 +481,19 @@ internal class SingleFileTransfer
 
     private bool ShouldSourceFileBeRestoredOnError()
     {
-        if (BatchContext.Options.RenameSourceFileBeforeTransfer)
-            return true;
+        if (BatchContext.Options.RenameSourceFileBeforeTransfer) return true;
 
-        if (BatchContext.Source.Operation == SourceOperation.Move)
-            return true;
+        if (BatchContext.Source.Operation == SourceOperation.Move) return true;
 
-        if (BatchContext.Source.Operation == SourceOperation.Rename)
-            return true;
+        if (BatchContext.Source.Operation == SourceOperation.Rename) return true;
 
         return false;
     }
 
-    /// <summary>
-    /// Handles logging of actions.
-    /// </summary>
-    /// <param name="state"></param>
-    /// <param name="format"></param>
-    /// <param name="args"></param>
-    private void Trace(TransferState state, string format, params object[] args)
+    private void SetCurrentState(TransferState state, string msg)
     {
         State = state;
-        _logger.NotifyTrace(string.Format("{0}: {1}", state, string.Format(format, args)));
+        _logger.NotifyTrace($"{state}: {msg}");
     }
 
     /// <summary>
@@ -457,7 +505,7 @@ internal class SingleFileTransfer
         /// Exception message.
         /// </summary>
         /// <param name="fileName"></param>
-        public DestinationFileExistsException(string fileName) : base(String.Format("Unable to transfer file. Destination file already exists: {0}", fileName)) { }
+        public DestinationFileExistsException(string fileName) : base($"Unable to transfer file. Destination file already exists: {fileName}") { }
     }
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -271,7 +271,7 @@ internal class SingleFileTransfer
             case FileEncoding.Other:
                 return Encoding.GetEncoding(dest.FileNameEncodingInString);
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException($"Unknown Encoding type: '{dest.FileContentEncoding}'.");
         }
     }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/TransferState.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/TransferState.cs
@@ -15,6 +15,9 @@ internal enum TransferState
     DeleteDestinationFile,
     RenameDestinationFile,
     CleanUpFiles,
-    CheckIfDestinationFileExists
+    CheckIfDestinationFileExists,
+    CreateDestinationDirectories,
+    Connection,
+    RestoreModified
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/WorkFileInfo.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/WorkFileInfo.cs
@@ -1,0 +1,26 @@
+﻿namespace Frends.SFTP.UploadFiles.Definitions;
+
+internal class WorkFileInfo
+{
+    public WorkFileInfo(string originalFileName, string workFileName, string workFileDir)
+    {
+        OriginalFileName = originalFileName ?? string.Empty;
+        WorkFileName = workFileName ?? string.Empty;
+        WorkFileDir = workFileDir ?? string.Empty;
+    }
+
+    public readonly string OriginalFileName;
+
+    public readonly string WorkFileName;
+
+    public readonly string WorkFileDir;
+
+    public string WorkFilePath
+    {
+        get
+        {
+            return Path.Combine(WorkFileDir, WorkFileName);
+        }
+    }
+}
+

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.cs
@@ -138,6 +138,7 @@ public class SFTP
             _batchContext = new BatchContext
             {
                 Info = info,
+                TempWorkDir = InitializeTemporaryWorkPath(info.WorkDir),
                 Options = options,
                 InstanceId = executionId,
                 ServiceId = info.TransferName,
@@ -162,6 +163,22 @@ public class SFTP
 
             return new Result(result);
         }
+    }
+
+    private static string InitializeTemporaryWorkPath(string workDir)
+    {
+        var tempWorkDir = GetTemporaryWorkPath(workDir);
+        Directory.CreateDirectory(tempWorkDir);
+        return tempWorkDir;
+    }
+
+    private static string GetTemporaryWorkPath(string workDir)
+    {
+        var tempWorkDirBase = workDir;
+
+        if (string.IsNullOrEmpty(workDir)) tempWorkDirBase = Path.GetTempPath();
+
+        return Path.Combine(tempWorkDirBase, Path.GetRandomFileName());
     }
 
     /// <summary>

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>1.0.2</Version>
+	  <Version>2.0.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -33,10 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-	<PackageReference Include="Newtonsoft.Json" Version="11.0.2">
-		<NoWarn>NU1605</NoWarn>
-	</PackageReference>
-	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
+	<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	<PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="SSH.NET" Version="2020.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />


### PR DESCRIPTION
- [Breaking] Changed the implementation to work similar to Cobalt by moving the source file to local Temp folder before transferring to destination.
- Fixed issue where PreserveModified caused exceptions because the method used wrong file path.
- Fixed bug where source files were deleted if RenameSourceFileBeforeTransfer was enabled and SourceOperation.Move had directory that didn't exist.
- Added logger usage in places where it was needed to make the operations log and error info more informative.
- Modified the logger usage that the logger.NotifyInformation is done after the action so it's easier to see where errors has occurred.