### PR TITLE
Fixed Issue 46: bug in checking the server fingerprint

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [2.0.3] - 2022-08-19
 ### Fixed
-- Fixed issue with server fingerprint given by user in hex format was not accepted.
-- Fixed issue when using invalid server fingerprint in MD5 string format throws wrong error message.
-- Fixed issue that Sha256 was only accepted in Base64 format.
+- Fixed issue with server fingerprint given by user in hex format was not accepted: Added conversion to the fingerprint given by user.
+- Fixed issue when using invalid server fingerprint in MD5 string format throws wrong error message: Added more specific error messages.
+- Fixed issue that Sha256 was only accepted in Base64 format: Added support for Sha256 in hex format.
 - Added support for Sha1 based server fingerprints.
 
 ## [2.0.2] - 2022-08-10

--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Fixed issue with server fingerprint given by user in hex format was not accepted.
 - Fixed issue when using invalid server fingerprint in MD5 string format throws wrong error message.
+- Fixed issue that Sha256 was only accepted in Base64 format.
 - Added support for Sha1 based server fingerprints.
 
 ## [2.0.2] - 2022-08-10

--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## [2.0.3] - 2022-08-19
 ### Fixed
-- Fixed issue with server fingerprint given by user in hex format was not accepted: Added conversion to the fingerprint given by user.
+- Fixed issue with server fingerprint given by user in SHA256 hex format was not accepted: Added conversion to the fingerprint given by user.
 - Fixed issue when using invalid server fingerprint in MD5 string format throws wrong error message: Added more specific error messages.
+- Changed how MD5 string is handled. MD5 can now be given without ':' or '-' characters.
 - Fixed issue that Sha256 was only accepted in Base64 format: Added support for Sha256 in hex format.
-- Added support for Sha1 based server fingerprints.
+- Changed the used HostKeyAlgorithm by forcing to use ssh-rsa default was ed25519.
+- Added more tests for using server fingerprints.
 
 ## [2.0.2] - 2022-08-10
 ### Fixed

--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.3] - 2022-08-19
+### Fixed
+- Fixed issue with server fingerprint given by user in hex format was not accepted.
+- Fixed issue when using invalid server fingerprint in MD5 string format throws wrong error message.
+- Added support for Sha1 based server fingerprints.
+
 ## [2.0.2] - 2022-08-10
 ### Fixed
 - Fixed issue where when using Rename options and appending / overwrite the task would throw an exception because the work directory given by user was used with renaming destination file.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using NUnit.Framework;
+using System.Net.Sockets;
 using Frends.SFTP.DownloadFiles.Definitions;
 
 namespace Frends.SFTP.DownloadFiles.Tests;
@@ -73,112 +74,6 @@ public class ConnectivityTests : DownloadFilesTestBase
         var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
         Assert.AreEqual(1, result.SuccessfulTransferCount);
-    }
-
-    [Test]
-    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsHexSha256()
-    {
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsSHA256HexString();
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        Assert.IsFalse(result.ActionSkipped);
-        Assert.AreEqual(1, result.SuccessfulTransferCount);
-    }
-
-    [Test]
-    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsSha256()
-    {
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsSHA256Base64String();
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        Assert.IsFalse(result.ActionSkipped);
-        Assert.AreEqual(1, result.SuccessfulTransferCount);
-    }
-
-    [Test]
-    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsSha1()
-    {
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsSHA1String();
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        Assert.IsFalse(result.ActionSkipped);
-        Assert.AreEqual(1, result.SuccessfulTransferCount);
-    }
-
-    [Test]
-    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5()
-    {
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsMD5HexString();
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        Assert.IsFalse(result.ActionSkipped);
-        Assert.AreEqual(1, result.SuccessfulTransferCount);
-    }
-
-    [Test]
-    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5Hash()
-    {
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsMD5HexString().Replace(":", "");
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        Assert.IsFalse(result.ActionSkipped);
-        Assert.AreEqual(1, result.SuccessfulTransferCount);
-    }
-
-    [Test]
-    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsMD5()
-    {
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = "73:58:DF:2D:CD:12:35:AB:7D:00:41:F0:1E:62:15:E0";
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
-        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
-    }
-
-    [Test]
-    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsHexSha256()
-    {
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = "c4b56fba6167c11f62e26b192c839d394e5c8d278b614b81345d037d178442f2";
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
-        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
-    }
-
-    [Test]
-    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsSha256()
-    {
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = "FBQn5eyoxpAl33Ly0gyScCGAqZeMVsfY7qss3KOM/hY=";
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
-        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
     }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
@@ -44,48 +44,6 @@ public class ConnectivityTests : DownloadFilesTestBase
     }
 
     [Test]
-    public void DownloadFiles_TestTransferWithMD5ServerFingerprint()
-    {
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsMD5String();
-
-        var source = new Source
-        {
-            Directory = _source.Directory,
-            FileName = _source.FileName,
-            Action = SourceAction.Error,
-            Operation = SourceOperation.Nothing
-        };
-
-        var result = SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        Assert.AreEqual(1, result.SuccessfulTransferCount);
-    }
-
-    [Test]
-    public void DownloadFiles_TestTransferWithSHA256ServerFingerprint()
-    {
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
-
-        var connection = Helpers.GetSftpConnection();
-        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsSHA256String();
-
-        var source = new Source
-        {
-            Directory = _source.Directory,
-            FileName = _source.FileName,
-            Action = SourceAction.Error,
-            Operation = SourceOperation.Nothing
-        };
-
-        var result = SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        Assert.AreEqual(1, result.SuccessfulTransferCount);
-    }
-
-    [Test]
     public void DownloadFiles_TestPrivateKeyFileRsa()
     {
         Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
@@ -115,6 +73,112 @@ public class ConnectivityTests : DownloadFilesTestBase
         var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
         Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsHexSha256()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsSHA256HexString();
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsSha256()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsSHA256Base64String();
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsSha1()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsSHA1String();
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsMD5HexString();
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5Hash()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = Helpers.GetServerFingerprintAsMD5HexString().Replace(":", "");
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsMD5()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = "73:58:DF:2D:CD:12:35:AB:7D:00:41:F0:1E:62:15:E0";
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
+    }
+
+    [Test]
+    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsHexSha256()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = "c4b56fba6167c11f62e26b192c839d394e5c8d278b614b81345d037d178442f2";
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
+    }
+
+    [Test]
+    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsSha256()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = "FBQn5eyoxpAl33Ly0gyScCGAqZeMVsfY7qss3KOM/hY=";
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
     }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Collections.Generic;
 using Renci.SshNet;
 using Renci.SshNet.Common;
+using Renci.SshNet.Security;
 using Frends.SFTP.DownloadFiles.Definitions;
 
 namespace Frends.SFTP.DownloadFiles.Tests;
@@ -146,6 +147,9 @@ internal static class Helpers
         Tuple<byte[], byte[]> result = null;
         using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
         {
+            client.ConnectionInfo.HostKeyAlgorithms.Clear();
+            client.ConnectionInfo.HostKeyAlgorithms.Add("ssh-rsa", (data) => { return new KeyHostAlgorithm("ssh-rsa", new RsaKey(), data); });
+
             client.HostKeyReceived += delegate (object sender, HostKeyEventArgs e)
             {
                 result = new Tuple<byte[], byte[]>(e.FingerPrint, e.HostKey);

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
@@ -141,106 +141,56 @@ internal static class Helpers
         }
     }
 
-    internal static string GetServerFingerprintAsMD5HexString()
+    internal static Tuple<byte[], byte[]> GetServerFingerPrintAndHostKey()
     {
-        var fingerprint = "";
+        Tuple<byte[], byte[]> result = null;
         using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
         {
             client.HostKeyReceived += delegate (object sender, HostKeyEventArgs e)
             {
-                fingerprint = BitConverter.ToString(e.FingerPrint).Replace("-", ":");
+                result = new Tuple<byte[], byte[]>(e.FingerPrint, e.HostKey);
                 e.CanTrust = true;
             };
             client.Connect();
             client.Disconnect();
         }
-
-        return fingerprint;
+        return result;
     }
 
-    internal static string GetServerFingerprintAsSHA256Base64String()
+    internal static string ConvertToMD5Hex(byte[] fingerPrint)
+    {
+        return BitConverter.ToString(fingerPrint).Replace("-", ":");
+    }
+
+    internal static string ConvertToSHA256Hash(byte[] hostKey)
     {
         var fingerprint = "";
-        using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
+        using (SHA256 mySHA256 = SHA256.Create())
         {
-            client.HostKeyReceived += delegate (object sender, HostKeyEventArgs e)
-            {
-                using (SHA256 mySHA256 = SHA256.Create())
-                {
-                    fingerprint = Convert.ToBase64String(mySHA256.ComputeHash(e.HostKey));
-                }
-                e.CanTrust = true;
-            };
-            client.Connect();
-            client.Disconnect();
+            fingerprint = Convert.ToBase64String(mySHA256.ComputeHash(hostKey));
         }
-
         return fingerprint;
     }
 
-    internal static string GetServerFingerprintAsSHA256HexString()
+    internal static string ConvertToSHA256Hex(byte[] hostKey)
     {
         var fingerprint = "";
-        using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
+        using (SHA256 mySHA256 = SHA256.Create())
         {
-            client.HostKeyReceived += delegate (object sender, HostKeyEventArgs e)
-            {
-                using (SHA256 mySHA256 = SHA256.Create())
-                {
-                    fingerprint = ToHex(mySHA256.ComputeHash(e.HostKey));
-                }
-                e.CanTrust = true;
-            };
-            client.Connect();
-            client.Disconnect();
+            fingerprint = ToHex(mySHA256.ComputeHash(hostKey));
         }
-
         return fingerprint;
     }
 
-    internal static string GetServerFingerprintAsSHA1String()
+    internal static string ConvertToSHA1(byte[] hostKey)
     {
         var fingerprint = "";
-        using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
+        using (var sha1 = SHA1.Create())
         {
-            client.HostKeyReceived += delegate (object sender, HostKeyEventArgs e)
-            {
-                using (var sha1 = SHA1.Create())
-                {
-                    var hash = sha1.ComputeHash(e.HostKey);
-                    fingerprint = string.Concat(hash.Select(b => b.ToString("x2")));
-                }
-                e.CanTrust = true;
-            };
-            client.Connect();
-            client.Disconnect();
+            var hash = sha1.ComputeHash(hostKey);
+            fingerprint = string.Concat(hash.Select(b => b.ToString("x2")));
         }
-
         return fingerprint;
-    }
-
-    internal static string HexStringToB64String(string input)
-    {
-        return Convert.ToBase64String(ConvertHexStringToHex(input));
-    }
-
-    internal static byte[] ConvertHexStringToHex(string hex)
-    {
-        var arr = new byte[hex.Length / 2];
-        for (var i = 0; i < arr.Length; i++)
-        {
-            arr[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
-        }
-        return arr;
-    }
-
-    internal static string ConvertHexStringToBase64(string hexString)
-    {
-        Func<char, int> parseNybble = c => (c >= '0' && c <= '9') ? c - '0' : char.ToLower(c) - 'a' + 10;
-        var bytes = Enumerable.Range(0, hexString.Length / 2)
-            .Select(x => (byte)((parseNybble(hexString[x * 2]) << 4) | parseNybble(hexString[x * 2 + 1])))
-            .ToArray();
-        return Convert.ToBase64String(bytes);
     }
 
     internal static string ToHex(byte[] bytes)

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ServerFingerprintTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ServerFingerprintTests.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using NUnit.Framework;
+using System.Net.Sockets;
+using Frends.SFTP.DownloadFiles.Definitions;
+
+namespace Frends.SFTP.DownloadFiles.Tests;
+
+[TestFixture]
+public class ServerFingerprintTests : DownloadFilesTestBase
+{
+    internal static string _MD5;
+    internal static string _Sha256Hex;
+    internal static string _Sha256Hash;
+    internal static string _Sha1;
+
+    [OneTimeSetUp]
+    public static void OneTimeSetup()
+    {
+        var (fingerPrint, hostKey) = Helpers.GetServerFingerPrintAndHostKey();
+        _MD5 = Helpers.ConvertToMD5Hex(fingerPrint);
+        _Sha1 = Helpers.ConvertToSHA1(hostKey);
+        _Sha256Hex = Helpers.ConvertToSHA256Hex(hostKey);
+        _Sha256Hash = Helpers.ConvertToSHA256Hash(hostKey);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsHexSha256()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = _Sha256Hex;
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsSha256()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = _Sha256Hash;
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsSha1()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = _Sha1;
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = _MD5;
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5Hash()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = _MD5.Replace(":", "");
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsMD5()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = "73:58:DF:2D:CD:12:35:AB:7D:00:41:F0:1E:62:15:E0";
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
+    }
+
+    [Test]
+    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsHexSha256()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = "c4b56fba6167c11f62e26b192c839d394e5c8d278b614b81345d037d178442f2";
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
+    }
+
+    [Test]
+    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsSha256()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = "FBQn5eyoxpAl33Ly0gyScCGAqZeMVsfY7qss3KOM/hY=";
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
+    }
+
+    [Test]
+    public void DownloadFiles_TestThrowsTransferWithInvalidExpectedServerFingerprintAsSha1()
+    {
+        var connection = Helpers.GetSftpConnection();
+        connection.ServerFingerPrint = "f6b1fa0ac7d00c615c340c2f3c8db92d2fabe905";
+
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
+    }
+}
+

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Connection.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Connection.cs
@@ -89,7 +89,8 @@ public class Connection
     /// <summary>
     /// Fingerprint of the SFTP server. When using "Username-Password" 
     /// authentication it is recommended to use server fingerprint in 
-    /// order to be sure of the server you are connecting.
+    /// order to be sure of the server you are connecting. Supported 
+    /// formats for server fingerprints: MD5 and SHA256. 
     /// </summary>
     /// <example>
     /// MD5: '41:76:EA:65:62:6E:D3:68:DC:41:9A:F2:F2:20:69:9D'

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -73,39 +73,73 @@ internal class FileTransporter
                 client.ConnectionInfo.KeyExchangeAlgorithms.Remove("curve25519-sha256");
                 client.ConnectionInfo.KeyExchangeAlgorithms.Remove("curve25519-sha256@libssh.org");
 
+                var expectedServerFingerprint = _batchContext.Connection.ServerFingerPrint;
                 // Check the fingerprint of the server if given.
-                if (!String.IsNullOrEmpty(_batchContext.Connection.ServerFingerPrint))
+                if (!string.IsNullOrEmpty(expectedServerFingerprint))
                 {
+                    SetCurrentState(TransferState.Connection, "Checking server fingerprint.");
                     try
                     {
-                        SetCurrentState(TransferState.Connection, "Checking server fingerprint.");
-                        // If this check fails then SSH.NET will throw an SshConnectionException - with a message of "Key exchange negotiation failed".
+                        #region HostKeyAuthentication
                         client.HostKeyReceived += delegate (object sender, HostKeyEventArgs e)
                         {
-                            // First try with SHA256 typed fingerprint
-                            using (SHA256 mySHA256 = SHA256.Create())
-                            {
-                                var sha256Fingerprint = Convert.ToBase64String(mySHA256.ComputeHash(e.HostKey));
-                                // Set the userResultMessage in case checking server fingerprint failes.
-                                userResultMessage = $"Can't trust SFTP server. The server fingerprint does not match. " +
-                                                        $"Expected fingerprint: '{_batchContext.Connection.ServerFingerPrint}', but was: '{sha256Fingerprint}'.";
-                                e.CanTrust = (sha256Fingerprint == _batchContext.Connection.ServerFingerPrint);
-                            }
-
-                            if (!e.CanTrust)
+                            if (Util.IsMD5(expectedServerFingerprint.Replace(":", "").Replace("-", "")))
                             {
                                 userResultMessage = $"Can't trust SFTP server. The server fingerprint does not match. " +
-                                                        $"Expected fingerprint: '{_batchContext.Connection.ServerFingerPrint}', but was: '{BitConverter.ToString(e.FingerPrint).Replace("-", ":")}'.";
-                                // If previous failed try with MD5 typed fingerprint
-                                var expectedFingerprint = Util.ConvertFingerprintToByteArray(_batchContext.Connection.ServerFingerPrint);
-                                e.CanTrust = (e.FingerPrint.SequenceEqual(expectedFingerprint));
-                            }
+                                            $"Expected fingerprint: '{expectedServerFingerprint}', but was: '{BitConverter.ToString(e.FingerPrint).Replace("-", "").Replace(":", "")}'.";
+                                e.CanTrust = expectedServerFingerprint == BitConverter.ToString(e.FingerPrint).Replace("-", "").Replace(":", "");
 
+                                if (!e.CanTrust)
+                                {
+                                    userResultMessage = $"Can't trust SFTP server. The server fingerprint does not match. " +
+                                                $"Expected fingerprint: '{expectedServerFingerprint}', but was: '{BitConverter.ToString(e.FingerPrint).Replace('-', ':')}'.";
+                                    e.CanTrust = e.FingerPrint.SequenceEqual(Util.ConvertFingerprintToByteArray(expectedServerFingerprint));
+                                }
+                                    
+                            }
+                            else if (Util.IsSha1(expectedServerFingerprint))
+                            {
+                                using (var sha1 = SHA1.Create())
+                                {
+                                    var hash = sha1.ComputeHash(e.HostKey);
+                                    var sha1Fingerprint = string.Concat(hash.Select(b => b.ToString("x2")));
+                                    userResultMessage = $"Can't trust SFTP server. The server fingerprint does not match. " +
+                                                            $"Expected fingerprint: '{expectedServerFingerprint}', but was: '{sha1Fingerprint}'.";
+                                    e.CanTrust = (sha1Fingerprint == expectedServerFingerprint);
+                                }
+                            }
+                            else
+                            {
+                                // Convert given fingerprint to Base64 format
+                                if (Util.TryConvertHexStringToHex(expectedServerFingerprint))
+                                {
+                                    using (SHA256 mySHA256 = SHA256.Create())
+                                    {
+                                        var sha256Fingerprint = Util.ToHex(mySHA256.ComputeHash(e.HostKey));
+                                        // Set the userResultMessage in case checking server fingerprint failes.
+                                        userResultMessage = $"Can't trust SFTP server. The server fingerprint does not match. " +
+                                                                $"Expected fingerprint: '{expectedServerFingerprint}', but was: '{sha256Fingerprint}'.";
+                                        e.CanTrust = (sha256Fingerprint == expectedServerFingerprint);
+                                    }
+                                } 
+                                else
+                                {
+                                    using (SHA256 mySHA256 = SHA256.Create())
+                                    {
+                                        var sha256Fingerprint = Convert.ToBase64String(mySHA256.ComputeHash(e.HostKey));
+                                        // Set the userResultMessage in case checking server fingerprint failes.
+                                        userResultMessage = $"Can't trust SFTP server. The server fingerprint does not match. " +
+                                                                $"Expected fingerprint: '{expectedServerFingerprint}', but was: '{sha256Fingerprint}'.";
+                                        e.CanTrust = (sha256Fingerprint == expectedServerFingerprint);
+                                    }
+                                }
+                            }
                         };
+                        #endregion HostKeyAuthentication
                     }
                     catch (Exception e)
                     {
-                        _logger.NotifyError(null, "Error when checking the server fingerprint: ", e);
+                        _logger.NotifyError(null, $"Error when checking the server fingerprint", e);
                         return FormFailedFileTransferResult(userResultMessage);
                     }
 
@@ -258,6 +292,11 @@ internal class FileTransporter
         connectionInfo.Encoding = GetEncoding(destination);
 
         return connectionInfo;
+    }
+
+    private static void CheckServerFingerprint(SftpClient client)
+    {
+
     }
 
     /// <summary>

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/HashType.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/HashType.cs
@@ -1,8 +1,0 @@
-﻿namespace Frends.SFTP.DownloadFiles.Definitions;
-
-internal enum HashType
-{
-    SHA256,
-    MD5
-}
-

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/HashType.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/HashType.cs
@@ -1,0 +1,8 @@
+﻿namespace Frends.SFTP.DownloadFiles.Definitions;
+
+internal enum HashType
+{
+    SHA256,
+    MD5
+}
+

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Util.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Util.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Frends.SFTP.DownloadFiles.Definitions;
@@ -95,7 +96,25 @@ internal static class Util
             return false;
         }
 
-        return Regex.IsMatch(input, "^[0-9a-fA-f]{40}$");
+        return Regex.IsMatch(input, "^[0-9a-fA-F]{40}$");
+    }
+
+    internal static bool IsSha256(string input)
+    {
+        if (String.IsNullOrEmpty(input))
+        {
+            return false;
+        }
+
+        if (Regex.IsMatch(input, "^[0-9a-fA-F]{64}$"))
+            return true;
+
+        try
+        {
+            Convert.FromBase64String(input);
+            return true;
+        } 
+        catch { return false; }
     }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Util.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Util.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Text;
 
 namespace Frends.SFTP.DownloadFiles.Definitions;
 
@@ -39,6 +40,62 @@ internal static class Util
     internal static byte[] ConvertFingerprintToByteArray(string fingerprint)
     {
         return fingerprint.Split(':').Select(s => Convert.ToByte(s, 16)).ToArray();
+    }
+
+    internal static string ToHex(byte[] bytes)
+    {
+        StringBuilder result = new StringBuilder(bytes.Length * 2);
+        for (int i = 0; i < bytes.Length; i++)
+            result.Append(bytes[i].ToString("x2"));
+        return result.ToString();
+    }
+
+    internal static bool TryConvertHexStringToHex(string hex)
+    {
+        try
+        {
+            var arr = new byte[hex.Length / 2];
+            for (var i = 0; i < arr.Length; i++)
+            {
+                arr[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            }
+            return true;
+        } catch { return false; }
+    }
+
+    internal static string HexStringToB64String(string input)
+    {
+        return Convert.ToBase64String(ConvertHexStringToHex(input));
+    }
+
+    internal static byte[] ConvertHexStringToHex(string hex)
+    {
+        var arr = new byte[hex.Length / 2];
+        for (var i = 0; i < arr.Length; i++)
+        {
+            arr[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        }
+        return arr;
+    }
+
+    internal static bool IsMD5(string input)
+    {
+        if (String.IsNullOrEmpty(input))
+        {
+            return false;
+        }
+
+        return Regex.IsMatch(input, "^[0-9a-fA-F]{32}$");
+    }
+
+    internal static bool IsSha1(string input)
+    {
+        if (String.IsNullOrEmpty(input))
+        {
+            return false;
+        }
+
+        return Regex.IsMatch(input, "^[0-9a-fA-f]{40}$");
     }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Util.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Util.cs
@@ -111,6 +111,8 @@ internal static class Util
 
         try
         {
+            if (!input.EndsWith("="))
+                input += '=';
             Convert.FromBase64String(input);
             return true;
         } 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.0.2</Version>
+	  <Version>2.0.3</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
- Fixed issue with MD5 typed server fingerprint given by user in hex format was not accepted.
- Fixed issue when using invalid server fingerprint in MD5 string format throws wrong error message.
- Fixed issue that Sha256 was only accepted in Base64 format.
- Added support for Sha1 based server fingerprints.