### PR TITLE
Fixed issue-59 by adding selector for hostKeyAlgotrithms

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+#[2.1.0] - 2022-09-09
+### Fixed
+- [Beaking] Removed UTF-16 and Unicode FileEncoding because their implementation didn't work. These were used as a parameter so autoupdate won't work.
+- Fixed how the Encoding on windows-1252 is handled. Added NuGet System.Text.Encoding.CodePages which can handle that encoding.
+- Fixed error handling by adding catch to FileTransporter to catch SftpPathNotFoundException and general Exception.
+- Added tests to test the file name and content encoding.
+- Updated the document to state that Ssh.Net only supports private keys in OpenSSH and ssh.com formats.
+- Added documentation on the private key formatingm from putty.ppk to OpenSSH.
+- Fixed HostKeyAlgorithm by removing the forcing of the ssh-rsa.
+- Added HostKeyAlgorithm parameter which enables users to change the host key algorithm used in the task. Before task defaults to ED25519.
+- Added enum HostKeyAlgorithms with the supported algorithms.
+- Modified tests to create testfiles instead of using files from project directory.
+
 ## [2.0.3] - 2022-08-19
 ### Fixed
 - Fixed issue with server fingerprint given by user in SHA256 hex format was not accepted: Added conversion to the fingerprint given by user.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
@@ -75,5 +75,29 @@ public class ConnectivityTests : DownloadFilesTestBase
         Assert.IsTrue(result.Success);
         Assert.AreEqual(1, result.SuccessfulTransferCount);
     }
+
+    [Test]
+    public void TestWithAzureBlobStorage()
+    {
+        var connection = new Connection()
+        {
+            ConnectionTimeout = 60,
+            Address = "frendstasktestsftp.blob.core.windows.net",
+            UserName = "frendstasktestsftp.tasktestuser",
+            Password = "zB2lciR4Q3+s3OoJpTB+LX2iXEDFsq39R+uHVsIzLZB67m6bdkUzv8rXvP0Xzc2qL4vqgK3Tn9jRB143vFktcA==",
+        };
+
+        var source = new Source()
+        {
+            Directory = "/download",
+            FileName = "downloadfile.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing
+        };
+
+        var result = SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/EncodingTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/EncodingTests.cs
@@ -1,0 +1,216 @@
+﻿using NUnit.Framework;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading;
+using Frends.SFTP.DownloadFiles.Definitions;
+
+namespace Frends.SFTP.DownloadFiles.Tests;
+
+[TestFixture]
+class EncodingTests : DownloadFilesTestBase
+{
+    [SetUp]
+    public void setup()
+    {
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithANSIFileNameEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileNameEncoding = FileEncoding.ANSI
+        };
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithASCIIFileNameEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileNameEncoding = FileEncoding.ASCII
+        };
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithUTF8WithoutBomFileNameEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = false
+        };
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithUTF8WithBomFileNameEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = true
+        };
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithWin1252FileNameEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileNameEncoding = FileEncoding.WINDOWS1252
+        };
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithOtherFileNameEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileNameEncoding = FileEncoding.Other,
+            FileNameEncodingInString = "windows-1252"
+        };
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithASCIIFileContentEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileContentEncoding = FileEncoding.ASCII,
+            Action = DestinationAction.Append
+        };
+
+        Directory.CreateDirectory(destination.Directory);
+        File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithANSIFileContentEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileContentEncoding = FileEncoding.ANSI,
+            Action = DestinationAction.Append
+        };
+
+        Directory.CreateDirectory(destination.Directory);
+        File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithUTF8WithBomFileContentEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileContentEncoding = FileEncoding.UTF8,
+            EnableBomForContent = true,
+            Action = DestinationAction.Append
+        };
+
+        Directory.CreateDirectory(destination.Directory);
+        File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithUTF8WithoutBomFileContentEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileContentEncoding = FileEncoding.UTF8,
+            EnableBomForContent = false,
+            Action = DestinationAction.Append
+        };
+
+        Directory.CreateDirectory(destination.Directory);
+        File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithWIN1252FileContentEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileContentEncoding = FileEncoding.WINDOWS1252,
+            Action = DestinationAction.Append
+        };
+
+        Directory.CreateDirectory(destination.Directory);
+        File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TransferWithOtherFileContentEncoding()
+    {
+        var destination = new Destination
+        {
+            Directory = _destination.Directory,
+            FileContentEncoding = FileEncoding.Other,
+            FileContentEncodingInString = "Windows-1252",
+            Action = DestinationAction.Append
+        };
+
+        Directory.CreateDirectory(destination.Directory);
+        File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
+
+        var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+    }
+}
+

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/DownloadFilesTestBase.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/DownloadFilesTestBase.cs
@@ -17,7 +17,7 @@ public class DownloadFilesTestBase
     protected static string _destWorkDir;
 
     [OneTimeSetUp]
-    public static void Setup()
+    public virtual void OneTimeSetup()
     {
         _workDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../../TestData/");
         _destWorkDir = Path.Combine(_workDir, "destination");
@@ -27,7 +27,7 @@ public class DownloadFilesTestBase
         _source = new Source
         {
             Directory = "/upload/Upload",
-            FileName = "SFTPDownloadTestFile.txt",
+            FileName = "SFTPDownloadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Nothing,
         };
@@ -56,6 +56,12 @@ public class DownloadFilesTestBase
         };
     }
 
+    [SetUp]
+    public virtual void Setup()
+    {
+        Helpers.CreateDummyFiles(3);
+    }
+
     [TearDown]
     public void TearDown()
     {
@@ -74,6 +80,8 @@ public class DownloadFilesTestBase
             if (Directory.Exists(_destWorkDir))
                 Directory.Delete(_destWorkDir, true);
         }
+
+        Helpers.DeleteDummyFiles();
     }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
@@ -20,6 +20,7 @@ internal static class Helpers
     readonly static string _dockerUsername = "foo";
     readonly static string _dockerPassword = "pass";
     readonly static string _baseDir = "/upload/";
+    readonly static string _workDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../../TestData/");
 
     internal static Connection GetSftpConnection()
     {
@@ -68,6 +69,26 @@ internal static class Helpers
 
             }
             client.Disconnect();
+        }
+    }
+    internal static void CreateDummyFiles(int count)
+    {
+        var name = "SFTPDownloadTestFile";
+        var extension = ".txt";
+        for (var i = 1; i <= count; i++)
+        {
+            File.WriteAllText(Path.Combine(_workDir, name + i + extension), "This is a test file.");
+        }
+    }
+
+    internal static void DeleteDummyFiles()
+    {
+        foreach (var file in Directory.EnumerateFileSystemEntries(_workDir))
+        {
+            if (Directory.Exists(file))
+                Directory.Delete(file, true);
+            if (!file.Contains("LargeTestFile.bin"))
+                File.Delete(file);
         }
     }
 
@@ -182,17 +203,6 @@ internal static class Helpers
         using (SHA256 mySHA256 = SHA256.Create())
         {
             fingerprint = ToHex(mySHA256.ComputeHash(hostKey));
-        }
-        return fingerprint;
-    }
-
-    internal static string ConvertToSHA1(byte[] hostKey)
-    {
-        var fingerprint = "";
-        using (var sha1 = SHA1.Create())
-        {
-            var hash = sha1.ComputeHash(hostKey);
-            fingerprint = string.Concat(hash.Select(b => b.ToString("x2")));
         }
         return fingerprint;
     }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/MacroTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/MacroTests.cs
@@ -25,7 +25,7 @@ internal class MacroTests : DownloadFilesTestBase
         var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
         var date = DateTime.Now;
-        Assert.IsTrue(File.Exists(Path.Combine(_destWorkDir, "SFTPDownloadTestFile" + date.ToString(@"yyyy-MM-dd") + ".txt")));
+        Assert.IsTrue(File.Exists(Path.Combine(_destWorkDir, "SFTPDownloadTestFile1" + date.ToString(@"yyyy-MM-dd") + ".txt")));
     }
 
     [Test]

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/PreserveModifiedTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/PreserveModifiedTests.cs
@@ -108,8 +108,8 @@ class PreserveModifiedTests : DownloadFilesTestBase
 
         var source = new Source
         {
-            Directory = "upload/Upload",
-            FileName = "SFTPDownloadTestFile.txt",
+            Directory = "/upload/Upload",
+            FileName = "SFTPDownloadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Delete,
         };

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ServerFingerprintTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ServerFingerprintTests.cs
@@ -16,12 +16,20 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     internal static string _Sha256Hash;
 
     [OneTimeSetUp]
-    public static void OneTimeSetup()
+    public override void OneTimeSetup()
     {
+        base.OneTimeSetup();
         var (fingerPrint, hostKey) = Helpers.GetServerFingerPrintAndHostKey();
         _MD5 = Helpers.ConvertToMD5Hex(fingerPrint);
         _Sha256Hex = Helpers.ConvertToSHA256Hex(hostKey);
         _Sha256Hash = Helpers.ConvertToSHA256Hash(hostKey);
+    }
+
+    [SetUp]
+    public override void Setup()
+    {
+        base.Setup();
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
     }
 
     [Test]
@@ -29,8 +37,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = _Sha256Hex;
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
@@ -42,10 +49,9 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsHexSha256WithAltercations()
     {
         var connection = Helpers.GetSftpConnection();
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
         connection.ServerFingerPrint = _Sha256Hash.Replace("=", "");
-        var test = connection.ServerFingerPrint;
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
@@ -58,8 +64,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = _Sha256Hash;
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
@@ -72,8 +77,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = _MD5;
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
@@ -86,8 +90,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = _MD5.ToLower();
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
@@ -100,8 +103,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = _MD5.Replace(":", "");
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
@@ -114,8 +116,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = "73:58:DF:2D:CD:12:35:AB:7D:00:41:F0:1E:62:15:E0";
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
         Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
@@ -126,8 +127,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = "c4b56fba6167c11f62e26b192c839d394e5c8d278b614b81345d037d178442f2";
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
         Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
@@ -138,8 +138,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = "nuDEsWN4tfEQ684+x+7RySiCwj+GXmX2CfBaBHeSqO8=";
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
         Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
@@ -150,8 +149,7 @@ public class ServerFingerprintTests : DownloadFilesTestBase
     {
         var connection = Helpers.GetSftpConnection();
         connection.ServerFingerPrint = "nuDEsWN4tfEQ684x7RySiCwjGXmX2CfBaBHeSqO8vfiurenvire56";
-
-        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
         var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
         Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/SourceOperationTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/SourceOperationTests.cs
@@ -38,7 +38,7 @@ class SourceOperationTests : DownloadFilesTestBase
         var source = new Source
         {
             Directory = "upload/Upload",
-            FileName = "SFTPDownloadTestFile.txt",
+            FileName = "SFTPDownloadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Move,
             DirectoryToMoveAfterTransfer = to
@@ -89,7 +89,7 @@ class SourceOperationTests : DownloadFilesTestBase
         var source = new Source
         {
             Directory = "upload/Upload",
-            FileName = "SFTPDownloadTestFile.txt",
+            FileName = "SFTPDownloadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Rename,
             FileNameAfterTransfer = "uploaded_%SourceFileName%.txt"
@@ -122,7 +122,7 @@ class SourceOperationTests : DownloadFilesTestBase
         var source = new Source
         {
             Directory = "upload/Upload",
-            FileName = "SFTPDownloadTestFile.txt",
+            FileName = "SFTPDownloadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Move,
             DirectoryToMoveAfterTransfer = to
@@ -153,7 +153,7 @@ class SourceOperationTests : DownloadFilesTestBase
         var source = new Source
         {
             Directory = "upload/Upload",
-            FileName = "SFTPDownloadTestFile.txt",
+            FileName = "SFTPDownloadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Rename,
             FileNameAfterTransfer = "uploaded_%SourceFileName%.txt"
@@ -186,7 +186,7 @@ class SourceOperationTests : DownloadFilesTestBase
         var source = new Source
         {
             Directory = "upload/Upload",
-            FileName = "SFTPDownloadTestFile.txt",
+            FileName = "SFTPDownloadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Move,
             DirectoryToMoveAfterTransfer = to
@@ -217,7 +217,7 @@ class SourceOperationTests : DownloadFilesTestBase
         var source = new Source
         {
             Directory = "upload/Upload",
-            FileName = "SFTPDownloadTestFile.txt",
+            FileName = "SFTPDownloadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Rename,
             FileNameAfterTransfer = "uploaded_%SourceFileName%.txt"

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TestData/SFTPDownloadTestFile.txt
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TestData/SFTPDownloadTestFile.txt
@@ -1,1 +1,0 @@
-This is a Test file

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TestData/SFTPDownloadTestFile2.txt
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TestData/SFTPDownloadTestFile2.txt
@@ -1,1 +1,0 @@
-This is another test file

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TestData/SFTPDownloadTestFile3.txt
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TestData/SFTPDownloadTestFile3.txt
@@ -1,1 +1,0 @@
-This is a test file

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -80,7 +80,7 @@ class TransferTests : DownloadFilesTestBase
     {
         var files = new List<string>
         {
-            Path.Combine(_workDir, "SFTPDownloadTestFile.txt"),
+            Path.Combine(_workDir, "SFTPDownloadTestFile1.txt"),
             Path.Combine(_workDir, "SFTPDownloadTestFile2.txt"),
             Path.Combine(_workDir, "SFTPDownloadTestFile3.txt")
         };
@@ -147,7 +147,7 @@ class TransferTests : DownloadFilesTestBase
         var source = new Source
         {
             Directory = _source.Directory,
-            FileName = "*File.txt",
+            FileName = "*File1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Nothing
         };
@@ -164,7 +164,7 @@ class TransferTests : DownloadFilesTestBase
 
         var files = new List<string>
         {
-            Path.Combine(_workDir, "SFTPDownloadTestFile.txt"),
+            Path.Combine(_workDir, "SFTPDownloadTestFile1.txt"),
             Path.Combine(_workDir, "SFTPDownloadTestFile2.txt"),
             Path.Combine(_workDir, "SFTPDownloadTestFile3.txt"),
         };

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Connection.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Connection.cs
@@ -62,8 +62,10 @@ public class Connection
     public string PrivateKeyFile { get; set; }
 
     /// <summary>
-    /// Private key as a string, supported private key formats: PKCS#8,
-    /// PuTTY.ppk.
+    /// Private key as a string, supported private key formats: OpenSSH and ssh.com.
+    /// PuTTY keys can be converted with puttygen.exe application.
+    /// 1. Load your key file into puttygen.exe
+    /// 2. Conversion > Export OpenSSH key (not the "force new file format" option)
     /// </summary>
     /// <example>
     /// -----BEGIN RSA PRIVATE KEY-----
@@ -98,6 +100,15 @@ public class Connection
     /// </example>
     [DefaultValue("")]
     public string ServerFingerPrint { get; set; }
+
+    /// <summary>
+    /// Host key algorithm to use when connecting to server. 
+    /// Default value is Any which doesn't force the task to use 
+    /// specific algorithm.
+    /// </summary>
+    /// <example>HostKeyAlgorithm.RSA</example>
+    [DefaultValue(HostKeyAlgorithms.Any)]
+    public HostKeyAlgorithms HostKeyAlgorithm { get; set; }
 
     /// <summary>
     /// Integer value of used buffer size as KB.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Destination.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Destination.cs
@@ -43,7 +43,7 @@ public class Destination
     /// <summary>
     /// File encoding to be used. A partial list of possible encodings: https://en.wikipedia.org/wiki/Windows_code_page#List.
     /// </summary>
-    /// <example>utf-64</example>
+    /// <example>utf-8</example>
     [UIHint(nameof(FileNameEncoding), "", FileEncoding.Other)]
     public string FileNameEncodingInString { get; set; }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileEncoding.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileEncoding.cs
@@ -12,7 +12,6 @@ public enum FileEncoding
     ANSI,
     ASCII,
     WINDOWS1252,
-    Unicode,
     /// <summary>
     /// Other enables users to add other encoding options as string.
     /// </summary>

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -253,7 +253,7 @@ internal class FileTransporter
         }
 
         connectionInfo = new ConnectionInfo(connect.Address, connect.Port, connect.UserName, methods.ToArray());
-        connectionInfo.Encoding = GetEncoding(destination);
+        connectionInfo.Encoding = Util.GetEncoding(destination.FileNameEncoding, destination.FileNameEncodingInString, destination.EnableBomForFileName);
 
         return connectionInfo;
     }
@@ -350,31 +350,6 @@ internal class FileTransporter
             if (!e.CanTrust)
                 _logger.NotifyError(_batchContext, userResultMessage, new SshConnectionException());
         };
-    }
-
-    /// <summary>
-    /// Get encoding for the file name to be transferred.
-    /// </summary>
-    /// <param name="dest"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    private static Encoding GetEncoding(Destination dest)
-    {
-        switch (dest.FileNameEncoding)
-        {
-            case FileEncoding.UTF8:
-                return dest.EnableBomForFileName ? new UTF8Encoding(true) : new UTF8Encoding(false);
-            case FileEncoding.ASCII:
-                return new ASCIIEncoding();
-            case FileEncoding.ANSI:
-                return Encoding.Default;
-            case FileEncoding.WINDOWS1252:
-                return CodePagesEncodingProvider.Instance.GetEncoding("windows-1252");
-            case FileEncoding.Other:
-                return CodePagesEncodingProvider.Instance.GetEncoding(dest.FileNameEncodingInString);
-            default:
-                throw new ArgumentOutOfRangeException($"Unknown Encoding type: '{dest.FileNameEncoding}'.");
-        }
     }
 
     /// <summary>

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -373,7 +373,7 @@ internal class FileTransporter
             case FileEncoding.Other:
                 return CodePagesEncodingProvider.Instance.GetEncoding(dest.FileNameEncodingInString);
             default:
-                throw new ArgumentOutOfRangeException($"Unknown Encoding type: '{dest.FileContentEncoding}'.");
+                throw new ArgumentOutOfRangeException($"Unknown Encoding type: '{dest.FileNameEncoding}'.");
         }
     }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/HostKeyAlgorithms.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/HostKeyAlgorithms.cs
@@ -1,0 +1,37 @@
+﻿namespace Frends.SFTP.DownloadFiles.Definitions;
+
+/// <summary>
+/// Enumeration for host key algorithms.
+/// </summary>
+public enum HostKeyAlgorithms
+{
+    /// <summary>
+    /// The algorithm is negotiated with the server.
+    /// </summary>
+    Any,
+    /// <summary>
+    /// Force the ssh-rsa host key algorithm.
+    /// </summary>
+    RSA,
+    /// <summary>
+    /// Force the ssh-ed25519 host key algorithm.
+    /// </summary>
+    Ed25519,
+    /// <summary>
+    /// Force the ssh-dss host key algorithm.
+    /// </summary>
+    DSS,
+    /// <summary>
+    /// Force the ecdsa-sha2-nistp256 host key algorithm.
+    /// </summary>
+    nistp256,
+    /// <summary>
+    /// Force the ecdsa-sha2-nistp384 host key algorithm.
+    /// </summary>
+    nistp384,
+    /// <summary>
+    /// Force the ecdsa-sha2-nistp521 host key algorithm.
+    /// </summary>
+    nistp521
+}
+

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SingleFileTransfer.cs
@@ -273,20 +273,18 @@ internal class SingleFileTransfer
 
     private static Encoding GetEncoding(Destination dest)
     {
-        switch (dest.FileContentEncoding)
+        switch (dest.FileNameEncoding)
         {
             case FileEncoding.UTF8:
-                return dest.EnableBomForContent ? new UTF8Encoding(true) : new UTF8Encoding(false);
+                return dest.EnableBomForFileName ? new UTF8Encoding(true) : new UTF8Encoding(false);
             case FileEncoding.ASCII:
-                return Encoding.ASCII;
+                return new ASCIIEncoding();
             case FileEncoding.ANSI:
                 return Encoding.Default;
-            case FileEncoding.Unicode:
-                return Encoding.Unicode;
             case FileEncoding.WINDOWS1252:
-                return Encoding.Default;
+                return CodePagesEncodingProvider.Instance.GetEncoding("windows-1252");
             case FileEncoding.Other:
-                return Encoding.GetEncoding(dest.FileContentEncodingInString);
+                return CodePagesEncodingProvider.Instance.GetEncoding(dest.FileNameEncodingInString);
             default:
                 throw new ArgumentOutOfRangeException($"Unknown Encoding type: '{dest.FileContentEncoding}'.");
         }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SingleFileTransfer.cs
@@ -154,7 +154,7 @@ internal class SingleFileTransfer
         Encoding encoding;
         try
         {
-            encoding = GetEncoding(BatchContext.Destination);
+            encoding = Util.GetEncoding(BatchContext.Destination.FileContentEncoding, BatchContext.Destination.FileContentEncodingInString, BatchContext.Destination.EnableBomForContent);
         }
         catch (Exception ex)
         {
@@ -269,25 +269,6 @@ internal class SingleFileTransfer
             $"Restoring the modified datetime of transferred file {Path.GetFileName(DestinationFileWithMacrosExpanded)}");
         File.SetLastWriteTime(DestinationFileWithMacrosExpanded, date);
         _logger.NotifyInformation(BatchContext, $"SET MODIFIED {date.ToString("dd.MM.yyyy hh:mm:ss")}");
-    }
-
-    private static Encoding GetEncoding(Destination dest)
-    {
-        switch (dest.FileContentEncoding)
-        {
-            case FileEncoding.UTF8:
-                return dest.EnableBomForContent ? new UTF8Encoding(true) : new UTF8Encoding(false);
-            case FileEncoding.ASCII:
-                return new ASCIIEncoding();
-            case FileEncoding.ANSI:
-                return Encoding.Default;
-            case FileEncoding.WINDOWS1252:
-                return CodePagesEncodingProvider.Instance.GetEncoding("windows-1252");
-            case FileEncoding.Other:
-                return CodePagesEncodingProvider.Instance.GetEncoding(dest.FileContentEncodingInString);
-            default:
-                throw new ArgumentOutOfRangeException($"Unknown Encoding type: '{dest.FileContentEncoding}'.");
-        }
     }
 
     private void ExecuteSourceOperationNothingOrDelete()

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Util.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Util.cs
@@ -118,5 +118,32 @@ internal static class Util
         } 
         catch { return false; }
     }
+
+    /// <summary>
+    /// Get encoding for the file name to be transferred.
+    /// </summary>
+    /// <param name="encoding"></param>
+    /// <param name="encodingString"></param>
+    /// <param name="enableBom"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    internal static Encoding GetEncoding(FileEncoding encoding, string encodingString, bool enableBom)
+    {
+        switch (encoding)
+        {
+            case FileEncoding.UTF8:
+                return enableBom ? new UTF8Encoding(true) : new UTF8Encoding(false);
+            case FileEncoding.ASCII:
+                return new ASCIIEncoding();
+            case FileEncoding.ANSI:
+                return Encoding.Default;
+            case FileEncoding.WINDOWS1252:
+                return CodePagesEncodingProvider.Instance.GetEncoding("windows-1252");
+            case FileEncoding.Other:
+                return CodePagesEncodingProvider.Instance.GetEncoding(encodingString);
+            default:
+                throw new ArgumentOutOfRangeException($"Unknown Encoding type: '{encoding}'.");
+        }
+    }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.0.3</Version>
+	  <Version>2.1.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>
@@ -37,6 +37,7 @@
 	<PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="SSH.NET" Version="2020.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+	<PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- [Beaking] Removed UTF-16 and Unicode FileEncoding because their implementation didn't work. These were used as a parameter so autoupdate won't work.
- Fixed how the Encoding on windows-1252 is handled. Added NuGet System.Text.Encoding.CodePages which can handle that encoding.
- Fixed error handling by adding catch to FileTransporter to catch SftpPathNotFoundException and general Exception.
- Added tests to test the file name and content encoding.
- Updated the document to state that Ssh.Net only supports private keys in OpenSSH and ssh.com formats.
- Added documentation on the private key formatingm from putty.ppk to OpenSSH.
- Fixed HostKeyAlgorithm by removing the forcing of the ssh-rsa.
- Added HostKeyAlgorithm parameter which enables users to change the host key algorithm used in the task. Before task defaults to ED25519.
- Added enum HostKeyAlgorithms with the supported algorithms.
- Modified tests to create testfiles instead of using files from project directory.