### PR TITLE
Frends.SFTP.DownloadFiles bug fix for error handler

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#[2.1.1] - 2022-09-16
+### Fixed
+- Fixed error handler by adding connection check to FileTransporter and SingleFileTransfer classes. If the client is not connected the task tries to connect again before handling errors.
+
 #[2.1.0] - 2022-09-09
 ### Fixed
 - [Beaking] Removed UTF-16 and Unicode FileEncoding because their implementation didn't work. These were used as a parameter so autoupdate won't work.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -160,9 +160,14 @@ internal class FileTransporter
                     foreach (var file in files)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
+
+                        // Check that the connection is alive and if not try to connect again
+                        if (!client.IsConnected)
+                            client.Connect();
+
                         var singleTransfer = new SingleFileTransfer(file, _batchContext, client, _renamingPolicy, _logger);
                         var result = singleTransfer.TransferSingleFile();
-                        _result.Add(result);
+                        _result.Add(result); 
                     }
                     client.Disconnect();
                 }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SingleFileTransfer.cs
@@ -428,6 +428,10 @@ internal class SingleFileTransfer
 
     private string RestoreSourceFileAfterErrorIfItWasRenamed()
     {
+        // Check that the connection is alive and if not try to connect again
+        if (!Client.IsConnected)
+            Client.Connect();
+
         // restore the source file so we can retry the operations
         // - but only if the source file has been renamed in the first place
         if (!string.IsNullOrEmpty(SourceFileDuringTransfer))

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.1.0</Version>
+	  <Version>2.1.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
Fixed issue 51 by adding connection check
- Fixed error handler by adding connection check to FileTransporter and SingleFileTransfer classes. If the client is not connected the task tries to connect again before handling errors.