### PR TITLE
Frends.SFTP.UploadFiles bug fix for error handler

### DIFF
--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+#[2.1.2] - 2022-09-16
+### Fixed
+- Fixed error handler by adding connection check to FileTransporter and SingleFileTransfer classes. If the client is not connected the task tries to connect again before handling errors.
+- Added some tests and separated Appending tests to their own class.
+
 #[2.1.1] - 2022-09-14
 ### Updated
 - Updated depricated library Microsoft.Extensions.DependencyInjection from 5.0.1 to 6.0.0

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/AppendTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/AppendTests.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using NUnit.Framework;
+using Frends.SFTP.UploadFiles.Definitions;
+
+namespace Frends.SFTP.UploadFiles.Tests;
+
+[TestFixture]
+class AppendTests : UploadFilesTestBase
+{
+    [Test]
+    public void UploadFiles_AppendingToExistingFile()
+    {
+        var result = SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var fullPath = _destination.Directory + "/" + _source.FileName;
+        var content1 = Helpers.GetTransferredFileContent(fullPath);
+
+        var destination = new Destination
+        {
+            Directory = "/upload/Upload",
+            FileName = "SFTPUploadTestFile1.txt",
+            Action = DestinationAction.Append,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile2.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing
+        };
+
+        result = SFTP.UploadFiles(source, destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var content2 = Helpers.GetTransferredFileContent(fullPath);
+        Assert.AreNotEqual(content1, content2);
+    }
+
+    [Test]
+    public void UploadFiles_AppendingToExistingFileRenameSourceFile()
+    {
+        var result = SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var fullPath = _destination.Directory + "/" + _source.FileName;
+        var content1 = Helpers.GetTransferredFileContent(fullPath);
+
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = true,
+            RenameDestinationFileDuringTransfer = false,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = true,
+            OperationLog = true
+        };
+
+        var destination = new Destination
+        {
+            Directory = "/upload/Upload",
+            FileName = "SFTPUploadTestFile1.txt",
+            Action = DestinationAction.Append,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile2.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing
+        };
+
+        result = SFTP.UploadFiles(source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var content2 = Helpers.GetTransferredFileContent(fullPath);
+        Assert.AreNotEqual(content1, content2);
+    }
+
+    [Test]
+    public void UploadFiles_AppendingToExistingFileRenameDestinationFile()
+    {
+        var result = SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var fullPath = _destination.Directory + "/" + _source.FileName;
+        var content1 = Helpers.GetTransferredFileContent(fullPath);
+
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = false,
+            RenameDestinationFileDuringTransfer = true,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = true,
+            OperationLog = true
+        };
+
+        var destination = new Destination
+        {
+            Directory = "/upload/Upload",
+            FileName = "SFTPUploadTestFile1.txt",
+            Action = DestinationAction.Append,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile2.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing
+        };
+
+        result = SFTP.UploadFiles(source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var content2 = Helpers.GetTransferredFileContent(fullPath);
+        Assert.AreNotEqual(content1, content2);
+    }
+
+    [Test]
+    public void UploadFiles_AppendingToExistingFileRenameBoth()
+    {
+        var result = SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var fullPath = _destination.Directory + "/" + _source.FileName;
+        var content1 = Helpers.GetTransferredFileContent(fullPath);
+
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = true,
+            RenameDestinationFileDuringTransfer = true,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = true,
+            OperationLog = true
+        };
+
+        var destination = new Destination
+        {
+            Directory = "/upload/Upload",
+            FileName = "SFTPUploadTestFile1.txt",
+            Action = DestinationAction.Append,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile2.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing
+        };
+
+        result = SFTP.UploadFiles(source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var content2 = Helpers.GetTransferredFileContent(fullPath);
+        Assert.AreNotEqual(content1, content2);
+    }
+
+    [Test]
+    public void UploadFiles_AppendingToExistingFileRenameBothWithSourceFileNameStar()
+    {
+        var result = SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var fullPath = _destination.Directory + "/" + _source.FileName;
+        var content1 = Helpers.GetTransferredFileContent(fullPath);
+
+        var options = new Options
+        {
+            ThrowErrorOnFail = true,
+            RenameSourceFileBeforeTransfer = true,
+            RenameDestinationFileDuringTransfer = true,
+            CreateDestinationDirectories = true,
+            PreserveLastModified = true,
+            OperationLog = true
+        };
+
+        var destination = new Destination
+        {
+            Directory = "/upload/Upload",
+            FileName = "SFTPUploadTestFile1.txt",
+            Action = DestinationAction.Append,
+            FileNameEncoding = FileEncoding.UTF8,
+            EnableBomForFileName = true
+        };
+
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile2.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing
+        };
+
+        result = SFTP.UploadFiles(source, destination, _connection, options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        var content2 = Helpers.GetTransferredFileContent(fullPath);
+        Assert.AreNotEqual(content1, content2);
+    }
+}
+

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
@@ -139,37 +139,6 @@ class TransferTests : UploadFilesTestBase
     }
 
     [Test]
-    public void UploadFiles_TestAppendToExistingFile()
-    {
-        var result = SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        var fullPath = _destination.Directory + "/" + _source.FileName;
-        var content1 = Helpers.GetTransferredFileContent(fullPath);
-
-        var destination = new Destination
-        {
-            Directory = "/upload/Upload",
-            FileName = "SFTPUploadTestFile1.txt",
-            Action = DestinationAction.Append,
-            FileNameEncoding = FileEncoding.UTF8,
-            EnableBomForFileName = true
-        };
-
-        var source = new Source
-        {
-            Directory = _workDir,
-            FileName = "SFTPUploadTestFile2.txt",
-            Action = SourceAction.Error,
-            Operation = SourceOperation.Nothing
-        };
-
-        result = SFTP.UploadFiles(source, destination, _connection, _options, _info, new CancellationToken());
-        Assert.IsTrue(result.Success);
-        var content2 = Helpers.GetTransferredFileContent(fullPath);
-        Assert.AreNotEqual(content1, content2);
-    }
-
-    [Test]
     public void UploadFiles_TestSingleFileTransferWithError()
     {
         var options = new Options

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -168,6 +168,11 @@ internal class FileTransporter
                     foreach (var file in files)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
+
+                        // Check that the connection is alive and if not try to connect again
+                        if (!client.IsConnected)
+                            client.Connect();
+
                         var singleTransfer = new SingleFileTransfer(file, DestinationDirectoryWithMacrosExtended, _batchContext, client, _renamingPolicy, _logger);
                         var result = singleTransfer.TransferSingleFile();
                         _result.Add(result);

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -412,6 +412,10 @@ internal class SingleFileTransfer
 
     private string RestoreSourceFileAfterError()
     {
+        // Check that the connection is alive and if not try to connect again
+        if (!Client.IsConnected)
+            Client.Connect();
+
         // restore the source file so we can retry the operations
         // - but only if the source file has been renamed in the first place
         if (!string.IsNullOrEmpty(SourceFileDuringTransfer))

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>2.1.1</Version>
+	  <Version>2.1.2</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
Fixed issue #52  by adding connection check
- Fixed error handler by adding connection check to FileTransporter and SingleFileTransfer classes. If the client is not connected the task tries to connect again before handling errors.
- Added some tests and separated Appending tests to their own class.