### PR TITLE
Fixed issue 69 by modifying how the error message is formed

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#[2.1.2] - 2022-09-23
+### Fixed
+- Fixed issue with the error message by changing how the error message is build. Error message had 'SFTP://' in both endpoints.
+
 ## [2.1.1] - 2022-09-16
 ### Fixed
 - Fixed error handler by adding connection check to FileTransporter and SingleFileTransfer classes. If the client is not connected the task tries to connect again before handling errors.

--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-#[2.1.2] - 2022-09-23
+## [2.1.2] - 2022-09-23
 ### Fixed
 - Fixed issue with the error message by changing how the error message is build. Error message had 'SFTP://' in both endpoints.
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
@@ -154,4 +154,16 @@ class ErrorTests : DownloadFilesTestBase
         Assert.That(ex.Message.StartsWith($"SFTP transfer failed: 1 Errors: Failure in CheckIfDestination"));
         Assert.IsTrue(Helpers.SourceFileExists(Path.Combine(_source.Directory, _source.FileName).Replace("\\", "/")));
     }
+
+    [Test]
+    public void DownloadFiles_TestErrorMessage()
+    {
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        var connection = Helpers.GetSftpConnection();
+        connection.Password = "cuinbeu8i9ch";
+
+        var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        var test = ex.Message;
+        Assert.That(ex.Message.Contains($"FRENDS SFTP file transfer '' from 'SFTP://localhost//upload/Upload/{_source.FileName}' to 'FILE://{_destination.Directory}':"));
+    }
 }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SFTPLogger.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SFTPLogger.cs
@@ -45,12 +45,12 @@ internal class SFTPLogger : ISFTPLogger
         {
             if (context == null) context = new BatchContext();
 
-            var sourceEndPointName = GetEndPointName(context, EndPoint.Source ,"unknown source end point");
+            var sourceEndPointName = GetEndPointName(context, EndPoint.Source, "unknown source end point");
             var destinationEndPointName = GetEndPointName(context, EndPoint.Destination, "unknown destination end point");
             var transferName = context.Info == null ? "unknown" : context.Info.TransferName;
             var transferNameForLog = transferName ?? string.Empty;
 
-            var errorMessage = string.Format("\r\n\r\nFRENDS SFTP file transfer '{0}' from '{1}' to '{2}': \r\n{3}\r\n", transferNameForLog, sourceEndPointName, destinationEndPointName, msg);
+            var errorMessage = $"\r\n\r\nFRENDS SFTP file transfer '{transferNameForLog}' from '{sourceEndPointName}' to '{destinationEndPointName}': \r\n{msg}\r\n";
             _log.Error(errorMessage, e);
         }
         catch (Exception ex)
@@ -124,9 +124,12 @@ internal class SFTPLogger : ISFTPLogger
         dynamic endpointConfig = (endpoint == EndPoint.Source) ? context.Source : context.Destination;
         if (endpointConfig == null || context.Connection.Address == null) return defaultValue;
 
+        if (endpoint == EndPoint.Destination)
+            return $"FILE://{context.Destination.Directory}";
+
         var directory = endpointConfig.Directory;
 
-        return string.Format("{0}://{1}/{2}/{3}", "SFTP", context.Connection.Address, directory, endpointConfig.FileName);
+        return $"SFTP://{context.Connection.Address}/{directory}/{endpointConfig.FileName}";
     }
 
     public static FileTransferInfo CreateFileTransferInfo(TransferResult result, SingleFileTransfer transfer, BatchContext context, string errorMessage = null)

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.1.1</Version>
+	  <Version>2.1.2</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#69 
- Fixed issue with the error message by changing how the error message is build. Error message had 'SFTP://' in both endpoints.