### PR TITLE
Fixed the issue with moving was not possible when renaming the file

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.1] - 2022-09-30
+### Fixed
+- Added possibility to give different directory to the task when using SourceOperation.Rename.
+- Updated documentation.
+
 ## [2.2.0] - 2022-09-26
 ### Fixed
 - [Breaking] Added option to enable keyboard-interactive authentication method. This change will break the automatic updates of the task.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/SourceOperationTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/SourceOperationTests.cs
@@ -345,4 +345,26 @@ class SourceOperationTests : DownloadFilesTestBase
         Assert.IsTrue(result.Success);
         Assert.IsFalse(Helpers.SourceFileExists(_source.Directory + "/" + _source.FileName));
     }
+
+    [Test]
+    public void DownloadFiles_TestSourceOperationRenameWithDifferentDirectory()
+    {
+        Helpers.UploadTestFiles(new List<string> { Path.Combine(_workDir, _source.FileName) }, _source.Directory);
+        Helpers.CreateSubDirectory("upload/moved");
+
+        var source = new Source
+        {
+            Directory = "upload/Upload",
+            FileName = "SFTPDownloadTestFile1.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Rename,
+            FileNameAfterTransfer = "upload/moved/uploaded_%SourceFileName%.txt"
+        };
+
+        var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(Helpers.SourceFileExists("upload/moved/uploaded_" + source.FileName));
+    }
 }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Source.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Source.cs
@@ -50,7 +50,7 @@ public class Source
     public string FileNameAfterTransfer { get; set; }
 
     /// <summary>
-    /// Parameter for Move operation. Set the full path to the directory without the file name. You can use some macros in the directory name, e.g. /subdir/%Year%_uploaded.txt.
+    /// Parameter for Move operation. Set the full path to the directory without the file name. You can use some macros in the directory name, e.g. /subdir/%Year%_uploaded/.
     /// </summary>
     /// <example>/upload/transferred/</example>
     [UIHint(nameof(Operation), "", SourceOperation.Move)]

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Source.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Source.cs
@@ -40,14 +40,17 @@ public class Source
     public SourceOperation Operation { get; set; }
 
     /// <summary>
-    /// Parameter for Rename operation. Set the file name for the source file.
+    /// Parameter for Rename operation. You can use file macros and also specify a directory 
+    /// where to move the files to, e.g. /subdir/%Date%file.txt. If you don't define a 
+    /// directory path, the source directory is used. When using rename, this parameter 
+    /// must always contain a file name.
     /// </summary>
     /// <example>transferred.txt</example>
     [UIHint(nameof(Operation), "", SourceOperation.Rename)]
     public string FileNameAfterTransfer { get; set; }
 
     /// <summary>
-    /// Parameter for Move operation. Set the full file path for source file.
+    /// Parameter for Move operation. Set the full path to the directory without the file name. You can use some macros in the directory name, e.g. /subdir/%Year%_uploaded.txt.
     /// </summary>
     /// <example>/upload/transferred/</example>
     [UIHint(nameof(Operation), "", SourceOperation.Move)]

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SourceOperation.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/SourceOperation.cs
@@ -1,16 +1,25 @@
-﻿// Pragma is for self-explanatory enum attributes.
-#pragma warning disable 1591
-
-namespace Frends.SFTP.DownloadFiles.Definitions;
+﻿namespace Frends.SFTP.DownloadFiles.Definitions;
 
 /// <summary>
 /// Enumeration to specify operation for the source file after transfer.
 /// </summary>
 public enum SourceOperation
 {
+    /// <summary>
+    /// Deletes the source file after transfer.
+    /// </summary>
     Delete,
+    /// <summary>
+    /// Renames the source file after transfer.
+    /// </summary>
     Rename,
+    /// <summary>
+    /// Moves the source file after transfer.
+    /// </summary>
     Move,
+    /// <summary>
+    /// Leaves the source file unchanged.
+    /// </summary>
     Nothing
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.2.0</Version>
+	  <Version>2.2.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#66 
- Added possibility to give different directory to the task when using SourceOperation.Rename.
- Updated documentation.