### PR TITLE
Frends.SFTP.UploadFiles Fixed issue where source files were not able to move when using SourceOperation.Rename

### DIFF
--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.1] - 2022-09-30
+### Fixed
+- Added possibility to give different directory to the task when using SourceOperation.Rename.
+- Updated documentation.
+
 ## [2.2.0] - 2022-09-28
 ### Fixed
 - [Breaking] Added option to enable keyboard-interactive authentication method. This change will break the automatic updates of the task.

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/SourceOperationTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/SourceOperationTests.cs
@@ -249,7 +249,7 @@ class SourceOperationTests : UploadFilesTestBase
             FileName = "SFTPUploadTestFile1.txt",
             Action = SourceAction.Error,
             Operation = SourceOperation.Rename,
-            FileNameAfterTransfer = Path.Combine(_workDir, "%Year%_uploaded\\uploaded_%SourceFileName%.txt")
+            FileNameAfterTransfer = Path.Combine(_workDir + "%Year%_uploaded", "uploaded_%SourceFileName%.txt")
         };
 
         var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/SourceOperationTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/SourceOperationTests.cs
@@ -1,7 +1,7 @@
 ﻿using NUnit.Framework;
 using System.IO;
 using System.Threading;
-using System.Collections.Generic;
+using System;
 using Frends.SFTP.UploadFiles.Definitions;
 
 namespace Frends.SFTP.UploadFiles.Tests;
@@ -214,6 +214,71 @@ class SourceOperationTests : UploadFilesTestBase
         Assert.IsFalse(result.Success);
 
         Assert.IsTrue(File.Exists(Path.Combine(_workDir, _source.FileName)));
+    }
+
+    [Test]
+    public void UploadFiles_TestSourceOperationWithRenameWithDifferentDirectory()
+    {
+        var to = Path.Combine(_workDir, "uploaded");
+        Directory.CreateDirectory(to);
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile1.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Rename,
+            FileNameAfterTransfer = Path.Combine(to, "uploaded_%SourceFileName%.txt")
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(File.Exists(Path.Combine(to, "uploaded_SFTPUploadTestFile1.txt")));
+    }
+
+    [Test]
+    public void UploadFiles_TestSourceOperationWithRenameWithDifferentDirectoryWithMacrosInDirectory()
+    {
+        var year = DateTime.Now.Year.ToString();
+        var to = Path.Combine(_workDir, $"{year}_uploaded");
+        Directory.CreateDirectory(to);
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile1.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Rename,
+            FileNameAfterTransfer = Path.Combine(_workDir, "%Year%_uploaded\\uploaded_%SourceFileName%.txt")
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(File.Exists(Path.Combine(to, "uploaded_SFTPUploadTestFile1.txt")));
+    }
+
+    [Test]
+    public void UploadFiles_TestSourceOperationWithRenameWithDifferentDirectoryWithMacrosInFileName()
+    {
+        var year = DateTime.Now.Year.ToString();
+        var to = Path.Combine(_workDir, $"{year}_uploaded");
+        Directory.CreateDirectory(to);
+        var source = new Source
+        {
+            Directory = _workDir,
+            FileName = "SFTPUploadTestFile1.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Rename,
+            FileNameAfterTransfer = Path.Combine(to, "uploaded_%SourceFileName%.txt")
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        Assert.IsTrue(File.Exists(Path.Combine(to, "uploaded_SFTPUploadTestFile1.txt")));
     }
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/Source.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/Source.cs
@@ -40,14 +40,18 @@ public class Source
     public SourceOperation Operation { get; set; }
 
     /// <summary>
-    /// Parameter for Rename operation. Set the file name for the source file.
+    /// Parameter for Rename operation. You can use file macros and also specify a directory 
+    /// where to move the files to, e.g. C:\subdir\%Date%file.txt. If you don't define a 
+    /// directory path, the source directory is used. When using rename, this parameter 
+    /// must always contain a file name.
     /// </summary>
     /// <example>transferred.txt</example>
     [UIHint(nameof(Operation), "", SourceOperation.Rename)]
     public string FileNameAfterTransfer { get; set; }
 
     /// <summary>
-    /// Parameter for Move operation. Set the full file path for source file.
+    /// Parameter for Move operation. Set the full path to the directory without the 
+    /// file name. You can use some macros in the directory name, e.g. C:\subdir\%Year%_uploaded\.
     /// </summary>
     /// <example>C:\directory\transferred\</example>
     [UIHint(nameof(Operation), "", SourceOperation.Move)]

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SourceOperation.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SourceOperation.cs
@@ -1,16 +1,25 @@
-﻿// Pragma is for self-explanatory enum attributes.
-#pragma warning disable 1591
-
-namespace Frends.SFTP.UploadFiles.Definitions;
+﻿namespace Frends.SFTP.UploadFiles.Definitions;
 
 /// <summary>
 /// Enumeration to specify operation for the source file after transfer.
 /// </summary>
 public enum SourceOperation
 {
+    /// <summary>
+    /// Deletes the source file after transfer.
+    /// </summary>
     Delete,
+    /// <summary>
+    /// Renames the source file after transfer.
+    /// </summary>
     Rename,
+    /// <summary>
+    /// Moves the source file after transfer.
+    /// </summary>
     Move,
+    /// <summary>
+    /// Leaves the source file unchanged.
+    /// </summary>
     Nothing
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>2.2.0</Version>
+	  <Version>2.2.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#67 
- Added possibility to give different directory to the task when using SourceOperation.Rename.
- Updated documentation.