### PR TITLE
Frends.SFTP.UploadFiles Fixed issue 58 by adding parameter for temp file extension

### DIFF
--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed operations log to use temp work path when getting source files to temp directory.
 - Added tests for the filePaths.
 
-## [2.3.0]
+## [2.3.0] - 2022-10-12
 ### Added
 - Added boolean parameter for adding a new line when appending to an existing file.
 - Changed the appending to use AppendAllText instead of AppendAllLines.

--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.4.0]
+### Added
+- [Breaking] Added parameters for the file extension of temporary source and destination files when rename options are enabled.
+- Fixed operations log to show correct state when source files are not found with filePaths.
+- Fixed operations log to use temp work path when getting source files to temp directory.
+- Added tests for the filePaths.
+
 ## [2.3.0]
 ### Added
 - Added boolean parameter for adding a new line when appending to an existing file.

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
@@ -110,5 +110,25 @@ class ErrorTesting : UploadFilesTestBase
         var ex = Assert.Throws<Exception>(() => SFTP.UploadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
         Assert.That(ex.Message.Contains(@$"FRENDS SFTP file transfer '' from 'FILE://{_source.Directory}/{_source.FileName}' to 'SFTP://{connection.Address}/{_destination.Directory}':"));
     }
+
+    [Test]
+    public void UploadFiles_TestThrowsWhenFilesInFilePathsAreNotFound()
+    {
+        var filePaths = Helpers.CreateDummyFiles(3);
+        foreach (var file in filePaths)
+        {
+            File.Delete(file.ToString());
+        }
+
+        var source = new Source
+        {
+            Action = SourceAction.Info,
+            Operation = SourceOperation.Nothing,
+            FilePaths = filePaths
+        };
+
+        var ex = Assert.Throws<Exception>(() => SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
+        Assert.That(ex.Message.Contains("Error when fetching source files: File does not exist"));
+    }
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
@@ -138,7 +138,7 @@ internal static class Helpers
         }
     }
 
-    internal static Array CreateDummyFiles(int count)
+    internal static string[] CreateDummyFiles(int count)
     {
         var filePaths = new List<string>();
         var name = "SFTPUploadTestFile";

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using Renci.SshNet;
 using Renci.SshNet.Common;
@@ -137,14 +138,20 @@ internal static class Helpers
         }
     }
 
-    internal static void CreateDummyFiles(int count)
+    internal static Array CreateDummyFiles(int count)
     {
+        var filePaths = new List<string>();
         var name = "SFTPUploadTestFile";
         var extension = ".txt";
+
         for (var i = 1; i <= count; i++)
         {
-            File.WriteAllText(Path.Combine(_workDir, name + i + extension), "This is a test file.");
+            var path = Path.Combine(_workDir, name + i + extension);
+            File.WriteAllText(path, "This is a test file.");
+            filePaths.Add(path);
         }
+
+        return filePaths.ToArray();
     }
 
     internal static void DeleteDummyFiles()

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
@@ -283,9 +283,47 @@ class TransferTests : UploadFilesTestBase
             BufferSize = 256
         };
 
+        var result = SFTP.UploadFiles(source, _destination, connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+    }
+
+    [Test]
+    public void UploadFiles_TestWithFilePaths()
+    {
+        var filePaths = Helpers.CreateDummyFiles(3);
+
+        var source = new Source
+        {
+            Action = SourceAction.Info,
+            Operation = SourceOperation.Nothing,
+            FilePaths = filePaths
+        };
+
         var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
         Assert.IsTrue(result.Success);
         Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(3, result.SuccessfulTransferCount);
+    }
+
+    [Test]
+    public void UploadFiles_TestWithFilePathsEvenIfSourceFileIsAssigned()
+    {
+        var filePaths = Helpers.CreateDummyFiles(3);
+
+        var source = new Source
+        {
+            Directory = _source.Directory,
+            FileName = "*.csv",
+            Action = SourceAction.Info,
+            Operation = SourceOperation.Nothing,
+            FilePaths = filePaths
+        };
+
+        var result = SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.ActionSkipped);
+        Assert.AreEqual(3, result.SuccessfulTransferCount);
     }
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileItem.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileItem.cs
@@ -25,7 +25,7 @@ internal class FileItem
     public FileItem(string fullPath)
     {
         if (!File.Exists(fullPath))
-            throw new ArgumentException($"File does not exist: '{fullPath}");
+            throw new FileNotFoundException($"File does not exist: '{fullPath}");
 
         var fi = new FileInfo(fullPath);
         Modified = fi.LastWriteTime;

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -162,8 +162,7 @@ internal class FileTransporter
                             return FormFailedFileTransferResult(userResultMessage);
                         }
                     }
-                    else
-                        // client.ChangeDirectory(DestinationDirectoryWithMacrosExtended);
+
 
                     _batchContext.DestinationFiles = client.ListDirectory(DestinationDirectoryWithMacrosExtended);
 
@@ -182,6 +181,12 @@ internal class FileTransporter
                     client.Disconnect();
                 }
             }   
+        }
+        catch (FileNotFoundException ex)
+        {
+            userResultMessage = $"Error when fetching source files: {ex.Message}, {userResultMessage}";
+            _logger.NotifyError(_batchContext, userResultMessage, ex);
+            return FormFailedFileTransferResult(userResultMessage);
         }
         catch (SshConnectionException ex)
         {
@@ -390,6 +395,8 @@ internal class FileTransporter
     /// <returns></returns>
     private Tuple<List<FileItem>, bool> GetSourceFiles(Source source)
     {
+        SetCurrentState(TransferState.CheckSourceFiles, "Checking source files.");
+
         var fileItems = new List<FileItem>();
 
         if (_filePaths != null)

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/Options.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/Options.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace Frends.SFTP.UploadFiles.Definitions;
 
@@ -22,11 +23,29 @@ public class Options
     public bool RenameSourceFileBeforeTransfer { get; set; }
 
     /// <summary>
+    /// File extension for the temporary source file which is used during the transfer.
+    /// </summary>
+    /// <example>.8CO</example>
+    [DefaultValue(".8CO")]
+    [UIHint(nameof(RenameSourceFileBeforeTransfer), "", true)]
+    [DisplayFormat(DataFormatString = "Text")]
+    public string SourceFileExtension { get; set; }
+
+    /// <summary>
     /// Should the destination file be renamed with temporary file name during file transfer as a locking mechanism.
     /// </summary>
     /// <example>true</example>
     [DefaultValue(true)]
     public bool RenameDestinationFileDuringTransfer { get; set; }
+
+    /// <summary>
+    /// File extension for the temporary destination file which is used during the transfer.
+    /// </summary>
+    /// <example>.8CO</example>
+    [DefaultValue(".8CO")]
+    [UIHint(nameof(RenameDestinationFileDuringTransfer), "", true)]
+    [DisplayFormat(DataFormatString = "Text")]
+    public string DestinationFileExtension { get; set; }
 
     /// <summary>
     /// Should the destination directories be created if they do not exist. May not work on all servers. 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -101,9 +101,9 @@ internal class SingleFileTransfer
         else
             SourceFileDuringTransfer = SourceFile.FullPath;
 
-        SetCurrentState(TransferState.GetFile, $"Downloading source file {Path.GetFileName(SourceFileDuringTransfer)} to local temp file {WorkFileInfo.WorkFilePath}");
+        SetCurrentState(TransferState.GetFile, $"Downloading source file {Path.GetFileName(SourceFileDuringTransfer)} to local temp file {WorkFileInfo.WorkFileDir}");
         File.Copy(SourceFileDuringTransfer, Path.Combine(WorkFileInfo.WorkFileDir, Path.GetFileName(SourceFileDuringTransfer)));
-        _logger.NotifyInformation(BatchContext, $"FILE COPY: {SourceFileDuringTransfer} to {WorkFileInfo.WorkFilePath}");
+        _logger.NotifyInformation(BatchContext, $"FILE COPY: {SourceFileDuringTransfer} to {WorkFileInfo.WorkFileDir}");
     }
 
     private bool DestinationFileExists(string path)
@@ -124,13 +124,13 @@ internal class SingleFileTransfer
             return;
         }
 
-        var uniqueFileName = Util.CreateUniqueFileName();
+        var uniqueFileName = Util.CreateUniqueFileName(BatchContext.Options.SourceFileExtension);
         var directory = Path.GetDirectoryName(SourceFile.FullPath);
         SourceFileDuringTransfer = Path.Combine(directory, uniqueFileName);
 
         SetCurrentState(TransferState.RenameSourceFileBeforeTransfer, $"Renaming source file {SourceFile.Name} to temporary file name {uniqueFileName} before transfer");
         File.Move(SourceFile.FullPath, SourceFileDuringTransfer);
-        _logger.NotifyInformation(BatchContext, $"FILE RENAME: Source file {SourceFile.Name} renamed to target {Path.GetFileName(SourceFileDuringTransfer)}.");
+        _logger.NotifyInformation(BatchContext, $"FILE RENAME: Source file {SourceFile.Name} renamed to target {uniqueFileName}.");
     }
 
     private void AppendDestinationFile()
@@ -165,7 +165,7 @@ internal class SingleFileTransfer
         }
         else
         {
-            var path = Path.Combine(Path.GetDirectoryName(DestinationFileWithMacrosExpanded), Util.CreateUniqueFileName());
+            var path = Path.Combine(Path.GetDirectoryName(DestinationFileWithMacrosExpanded), Util.CreateUniqueFileName(BatchContext.Options.DestinationFileExtension));
             DestinationFileDuringTransfer = (DestinationFileWithMacrosExpanded.Contains("/")) ? path.Replace("\\", "/") : path;
             SetCurrentState(TransferState.RenameDestinationFile, $"Renaming destination file {Path.GetFileName(DestinationFileWithMacrosExpanded)} to temporary file name {Path.GetFileName(DestinationFileDuringTransfer)} during transfer");
             Client.RenameFile(DestinationFileWithMacrosExpanded, DestinationFileDuringTransfer);
@@ -204,7 +204,7 @@ internal class SingleFileTransfer
     {
         var doRename = BatchContext.Options.RenameDestinationFileDuringTransfer;
 
-        DestinationFileDuringTransfer = doRename ? Path.Combine(Path.GetDirectoryName(DestinationFileWithMacrosExpanded), Util.CreateUniqueFileName()): DestinationFileWithMacrosExpanded;
+        DestinationFileDuringTransfer = doRename ? Path.Combine(Path.GetDirectoryName(DestinationFileWithMacrosExpanded), Util.CreateUniqueFileName(BatchContext.Options.DestinationFileExtension)): DestinationFileWithMacrosExpanded;
         if (DestinationFileWithMacrosExpanded.Contains('/')) DestinationFileDuringTransfer = DestinationFileDuringTransfer.Replace("\\", "/");
 
         var helper = doRename ? "temporary " : string.Empty;

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/TransferState.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/TransferState.cs
@@ -18,6 +18,7 @@ internal enum TransferState
     CheckIfDestinationFileExists,
     CreateDestinationDirectories,
     Connection,
-    RestoreModified
+    RestoreModified,
+    CheckSourceFiles
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/Util.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/Util.cs
@@ -8,9 +8,9 @@ namespace Frends.SFTP.UploadFiles.Definitions;
 /// </summary>
 internal static class Util
 {
-    internal static string CreateUniqueFileName()
+    internal static string CreateUniqueFileName(string fileExtension)
     {
-        return Path.ChangeExtension("frends_" + DateTime.Now.Ticks + Path.GetRandomFileName(), "8CO");
+        return Path.ChangeExtension("frends_" + DateTime.Now.Ticks + Path.GetRandomFileName(), fileExtension);
     }
 
     internal static bool FileMatchesMask(string filename, string mask)

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>2.3.2</Version>
+	  <Version>2.4.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>2.3.0</Version>
+	  <Version>2.3.2</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#58 
- [Breaking] Added parameters for the file extension of temporary source and destination files when rename options are enabled.
- Fixed operations log to show correct state when source files are not found with filePaths.
- Fixed operations log to use temp work path when getting source files to temp directory.
- Added tests for the filePaths.