### PR TITLE
DownloadFiles fixed issue 102 by adding name check

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [2.4.0] -2022-11-03
+## [2.4.1] - 2022-11-24
+### Fixed 
+- Fixed issue with files not found when the name consist of special characters by adding a check for the files exact name.
+
+## [2.4.0] - 2022-11-03
 ### Added
 - [Breaking] Added parameters for the file extension of temporary source and destination files when rename options are enabled.
 - Fixed task to enable transfers with file paths. 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
@@ -51,11 +51,11 @@ internal static class Helpers
         if (client.Exists(dir) && !dir.Equals(_baseDir)) client.DeleteDirectory(dir);
     }
 
-    internal static string[] UploadTestFiles(string destination, int count = 3, string to = null)
+    internal static string[] UploadTestFiles(string destination, int count = 3, string to = null, List<string> filenames = null)
     {
         var filePaths = new List<string>();
 
-        var files = CreateDummyFiles(count);
+        var files = (filenames == null) ? CreateDummyFiles(count) : CreateDummyFiles(0, filenames);
         using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
         {
             client.Connect();
@@ -83,7 +83,7 @@ internal static class Helpers
     {
         var filePaths = new List<string>();
 
-    var files = CreateLargeDummyFiles(count);
+        var files = CreateLargeDummyFiles(count);
         using (var client = new SftpClient(_dockerAddress, 2222, _dockerUsername, _dockerPassword))
         {
             client.Connect();
@@ -124,17 +124,29 @@ internal static class Helpers
         }
     }
 
-    internal static List<string> CreateDummyFiles(int count)
+    internal static List<string> CreateDummyFiles(int count, List<string> filenames = null)
     {
         Directory.CreateDirectory(_workDir);
         var filePaths = new List<string>();
-        var name = "SFTPDownloadTestFile";
-        var extension = ".txt";
-        for (var i = 1; i <= count; i++)
+        if (filenames == null)
         {
-            var path = Path.Combine(_workDir, name + i + extension);
-            File.WriteAllText(path, "This is a test file.");
-            filePaths.Add(path);
+            var name = "SFTPDownloadTestFile";
+            var extension = ".txt";
+            for (var i = 1; i <= count; i++)
+            {
+                var path = Path.Combine(_workDir, name + i + extension);
+                File.WriteAllText(path, "This is a test file.");
+                filePaths.Add(path);
+            }
+        }
+        else
+        {
+            foreach (var filename in filenames)
+            {
+                var path = Path.Combine(_workDir, filename);
+                File.WriteAllText(path, "This is a test file.");
+                filePaths.Add(path);
+            }
         }
 
         return filePaths;

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System.IO;
 using System.Threading;
+using System.Collections.Generic;
 using Frends.SFTP.DownloadFiles.Definitions;
 
 namespace Frends.SFTP.DownloadFiles.Tests;
@@ -302,6 +303,50 @@ class TransferTests : DownloadFilesTestBase
         var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
         Assert.AreEqual(3, result.SuccessfulTransferCount);
         Assert.IsTrue(result.Success);
+    }
+
+    [Test]
+    public void DownloadFiles_TestTransferWithSpecialCharactersInFileNames()
+    {
+        // upload test files
+        var files = new List<string> { "this is a test file.txt", "This_is(a test file).txt", "this is  { a test} file.txt" };
+        Helpers.UploadTestFiles(_source.Directory, 0, null, files);
+
+        var source = new Source
+        {
+            Directory = _source.Directory,
+            FileName = "this is a test file.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing,
+        };
+
+        var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        source = new Source
+        {
+            Directory = _source.Directory,
+            FileName = "This_is(a test file).txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing,
+        };
+
+        result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
+
+        source = new Source
+        {
+            Directory = _source.Directory,
+            FileName = "this is  { a test} file.txt",
+            Action = SourceAction.Error,
+            Operation = SourceOperation.Nothing,
+        };
+
+        result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.SuccessfulTransferCount);
     }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -429,7 +429,7 @@ internal class FileTransporter
 
             if (file.IsDirectory) continue;
 
-            if (Util.FileMatchesMask(Path.GetFileName(file.FullName), source.FileName))
+            if (file.Name.Equals(source.FileName) || Util.FileMatchesMask(Path.GetFileName(file.FullName), source.FileName))
             {
                 FileItem item = new FileItem(file);
                 _logger.NotifyInformation(_batchContext, $"FILE LIST {item.FullPath}.");

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.4.0</Version>
+	  <Version>2.4.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
- Fixed issue with files not found when the name consist of special characters by adding a check for the files exact name.