### PR TITLE
SFTP.UploadFiles Added parameter for KeepAliveInterval

### DIFF
--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.5.0] - 2022-12-30
+### Fixed
+- [Breaking] Fixed issue where keepaliveinterval and operationtimeout is set as the connectiontimeout by creating them for the keepaliveinterval its own parameter and removed operationtimeout.
+
 ## [2.4.1] - 2022-12-01
 ### Updated
 - Updated dependencies System.Text.Encoding.CodePages and Microsoft.Extensions.DependencyInjection to the newest version.

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ConnectivityTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ConnectivityTests.cs
@@ -114,6 +114,48 @@ namespace Frends.SFTP.UploadFiles.Tests
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
+
+        [Test]
+        public void DownloadFiles_TestKeepAliveIntervalWithDefault()
+        {
+            Helpers.CopyLargeTestFile(10);
+
+            var connection = Helpers.GetSftpConnection();
+
+            var source = new Source
+            {
+                Directory = _source.Directory,
+                FileName = "*.bin",
+                Action = SourceAction.Error,
+                Operation = SourceOperation.Nothing,
+            };
+
+            var result = SFTP.UploadFiles(source, _destination, connection, _options, _info, new CancellationToken());
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(11, result.SuccessfulTransferCount);
+        }
+
+        [Test]
+        public void DownloadFiles_TestKeepAliveIntervalWith1ms()
+        {
+            Helpers.CopyLargeTestFile(10);
+
+            var connection = Helpers.GetSftpConnection();
+            connection.KeepAliveInterval = 1;
+            connection.BufferSize = 256;
+
+            var source = new Source
+            {
+                Directory = _source.Directory,
+                FileName = "*.bin",
+                Action = SourceAction.Error,
+                Operation = SourceOperation.Nothing,
+            };
+
+            var result = SFTP.UploadFiles(source, _destination, connection, _options, _info, new CancellationToken());
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(11, result.SuccessfulTransferCount);
+        }
     }
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/Lib/Helpers.cs
@@ -31,7 +31,8 @@ namespace Frends.SFTP.UploadFiles.Tests
                 Port = 2222,
                 Authentication = AuthenticationType.UsernamePassword,
                 ServerFingerPrint = null,
-                BufferSize = 32
+                BufferSize = 32,
+                KeepAliveInterval = -1
             };
 
             return connection;

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/Connection.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/Connection.cs
@@ -18,6 +18,14 @@ public class Connection
     public int ConnectionTimeout { get; set; }
 
     /// <summary>
+    /// The keep-alive interval in milliseconds. Interval the client send keep-alive packages to the host.
+    /// You can use value -1 to disable the keep-alive.
+    /// </summary>
+    /// <example>-1</example>
+    [DefaultValue(-1)]
+    public int KeepAliveInterval { get; set; }
+
+    /// <summary>
     /// SFTP host address
     /// </summary>
     /// <example>localhost</example>

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -120,8 +120,7 @@ internal class FileTransporter
                     }
 
                     client.ConnectionInfo.Timeout = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout);
-                    client.OperationTimeout = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout);
-                    client.KeepAliveInterval = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout);
+                    client.KeepAliveInterval = TimeSpan.FromMilliseconds(_batchContext.Connection.KeepAliveInterval);
 
                     client.BufferSize = _batchContext.Connection.BufferSize * 1024;
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>2.4.1</Version>
+	  <Version>2.5.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#117 
[Breaking] Fixed issue where keepaliveinterval and operationtimeout is set as the connectiontimeout by creating them for the keepaliveinterval its own parameter and removed operationtimeout.