### PR TITLE
SFTP.DownloadFiles Fixed empty source dir and userResultMessage

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.5.1] - 2022-12-30
+### Fixed
+- Fixed issue with empty source dir throws an exception by setting empty source directory as '/'.
+- Fixed issue with when no source files userResultMessage still said no. files transferred and not no files transferred.
+
 ## [2.5.0] - 2022-12-16
 ### Fixed
 - [Breaking] Fixed issue where keepaliveinterval and operationtimeout is set as the connectiontimeout by creating them for the keepaliveinterval its own parameter and removed operationtimeout.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
@@ -16,7 +16,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             File.Copy(Path.Combine(_workDir, _source.FileName), Path.Combine(_destWorkDir, _source.FileName));
 
             var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, _connection, _options, _info, new CancellationToken()));
-            Assert.That(ex.Message.StartsWith($"SFTP transfer failed: 1 Errors: Failure in CheckIfDestination"));
+            Assert.IsTrue(ex.Message.StartsWith($"SFTP transfer failed: 1 Errors: Failure in CheckIfDestination"));
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             };
 
             var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
-            Assert.That(ex.Message.StartsWith("SFTP transfer failed: 1 Errors: No source files found from directory"));
+            Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: 1 Errors: No source files found from directory"));
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.Port = 51651;
 
             var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
-            Assert.That(ex.Message.StartsWith("SFTP transfer failed: Unable to establish the socket: No such host is known"));
+            Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Unable to establish the socket: No such host is known"));
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             };
 
             var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
-            Assert.That(ex.Message.StartsWith("SFTP transfer failed: 1 Errors: No source files found from directory"));
+            Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: 1 Errors: No source files found from directory"));
 
             Helpers.DeleteSubDirectory(path);
         }
@@ -157,7 +157,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.Password = "cuinbeu8i9ch";
 
             var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
-            Assert.That(ex.Message.Contains($"FRENDS SFTP file transfer '' from 'SFTP://localhost//upload/Upload/{_source.FileName}' to 'FILE://{_destination.Directory}':"));
+            Assert.IsTrue(ex.Message.Contains($"FRENDS SFTP file transfer '' from 'SFTP://localhost//upload/Upload/{_source.FileName}' to 'FILE://{_destination.Directory}':"));
         }
     }
 }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System;
 using System.IO;
 using System.Threading;
 using System.Collections.Generic;
@@ -15,6 +16,21 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var result = SFTP.DownloadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
+        }
+
+        [Test]
+        public void DownloadFiles_TestTransferWithoutSourceDirectoryShouldThrow()
+        {
+            var source = new Source
+            {
+                Directory = "",
+                FileName = _source.FileName,
+                Action = _source.Action,
+                Operation = _source.Operation,
+            };
+
+            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
+            Assert.IsTrue(ex.Message.Contains("No source"));
         }
 
         [Test]
@@ -102,6 +118,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Assert.IsFalse(result.Success);
             Assert.AreEqual(2, result.SuccessfulTransferCount);
             Assert.AreEqual(1, result.FailedTransferCount);
+            Assert.IsTrue(result.UserResultMessage.Contains("2 files transferred:"));
         }
 
         [Test]
@@ -223,6 +240,8 @@ namespace Frends.SFTP.DownloadFiles.Tests
 
             var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.ActionSkipped);
+            Assert.IsFalse(result.UserResultMessage.Contains("1 files transferred"));
+            Assert.IsTrue(result.UserResultMessage.Contains("No files transferred"));
         }
 
         [Test]
@@ -249,6 +268,8 @@ namespace Frends.SFTP.DownloadFiles.Tests
 
             var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.ActionSkipped);
+            Assert.IsFalse(result.UserResultMessage.Contains("1 files transferred"));
+            Assert.IsTrue(result.UserResultMessage.Contains("No files transferred"));
         }
 
         [Test]

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -29,7 +29,7 @@ internal class FileTransporter
         _filePaths = ConvertObjectToStringArray(context.Source.FilePaths);
 
         if (_filePaths == null || !_filePaths.Any())
-            SourceDirectoryWithMacrosExtended = _renamingPolicy.ExpandDirectoryForMacros(context.Source.Directory);
+            SourceDirectoryWithMacrosExtended = string.IsNullOrEmpty(context.Source.Directory) ? "/" : _renamingPolicy.ExpandDirectoryForMacros(context.Source.Directory);
 
         DestinationDirectoryWithMacrosExtended = _renamingPolicy.ExpandDirectoryForMacros(context.Destination.Directory);
     }
@@ -512,7 +512,7 @@ internal class FileTransporter
             userResultMessage = MessageJoin(userResultMessage,
                 $"{errorMessages.Count} Errors: {string.Join(", \n", errorMessages)}.");
 
-        var transferredFiles = results.Where(x => x.Success).Select(x => x.TransferredFile).ToList();
+        var transferredFiles = results.Where(x => x.Success && !x.ActionSkipped).Select(x => x.TransferredFile).ToList();
         if (transferredFiles.Any())
             userResultMessage = MessageJoin(userResultMessage,
                 $"{transferredFiles.Count} files transferred: {string.Join(", \n", transferredFiles)}.");

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.5.0</Version>
+	  <Version>2.5.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
Fixed issues #105  and #104 
- Fixed issue with empty source dir throws an exception by setting empty source directory as '/'.
- Fixed issue with when no source files userResultMessage still said no. files transferred and not no files transferred.