### PR TITLE
SFTP.UploadFiles Fixed issue task trying rename source file

### DIFF
--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.5.4] - 2023-02-24
+### Fixed
+- Fixed bug with task trying to rename the source file after exception without it being renamed in the first place.
+
 ## [2.5.3] - 2023-02-21
 ### Fixed
 - Fixed bug with FilePaths when using list of objects in parameter.

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
@@ -134,26 +134,10 @@ namespace Frends.SFTP.UploadFiles.Tests
         [Test]
         public void UploadFiles_TestTransferThatThrowsWhenFileIsLocked()
         {
-            var ex = Assert.Throws<Exception>(() => UploadFileWhileFileIsLocked());
-            Assert.IsFalse(ex.Message.Contains("Could not restore original source file"));
-        }
-
-        private static void UploadFileWhileFileIsLocked()
-        {
-            FileStream stream = null;
-            try
+            using (var stream = File.Open(Path.Combine(_workDir, "SFTPUploadTestFile1.txt"), FileMode.Open, FileAccess.Read, FileShare.None))
             {
-                stream = File.Open(Path.Combine(_workDir, "SFTPUploadTestFile1.txt"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
-            }
-            catch (Exception ex)
-            {
-                if (stream != null)
-                {
-                    stream.Close();
-                    stream.Dispose();
-                }
-                throw ex;
+                var ex = Assert.Throws<Exception>(() => SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken()));
+                Assert.IsFalse(ex.Message.Contains("Could not restore original source file"));
             }
         }
     }

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
@@ -134,10 +134,16 @@ namespace Frends.SFTP.UploadFiles.Tests
         [Test]
         public void UploadFiles_TestTransferThatThrowsWhenFileIsLocked()
         {
+            
+                var ex = Assert.Throws<Exception>(() => UploadFileWhileFileIsLocked());
+                Assert.IsFalse(ex.Message.Contains("Could not restore original source file"));
+        }
+
+        private static void UploadFileWhileFileIsLocked()
+        {
             using (var stream = File.OpenRead(Path.Combine(_workDir, "SFTPUploadTestFile1.txt")))
             {
-                var ex = Assert.Throws<Exception>(() => SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken()));
-                Assert.IsFalse(ex.Message.Contains("Could not restore original source file"));
+                SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
             }
         }
     }

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
@@ -134,9 +134,8 @@ namespace Frends.SFTP.UploadFiles.Tests
         [Test]
         public void UploadFiles_TestTransferThatThrowsWhenFileIsLocked()
         {
-            
-                var ex = Assert.Throws<Exception>(() => UploadFileWhileFileIsLocked());
-                Assert.IsFalse(ex.Message.Contains("Could not restore original source file"));
+            var ex = Assert.Throws<Exception>(() => UploadFileWhileFileIsLocked());
+            Assert.IsFalse(ex.Message.Contains("Could not restore original source file"));
         }
 
         private static void UploadFileWhileFileIsLocked()

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
@@ -140,9 +140,20 @@ namespace Frends.SFTP.UploadFiles.Tests
 
         private static void UploadFileWhileFileIsLocked()
         {
-            using (var stream = File.OpenRead(Path.Combine(_workDir, "SFTPUploadTestFile1.txt")))
+            FileStream stream = null;
+            try
             {
+                stream = File.Open(Path.Combine(_workDir, "SFTPUploadTestFile1.txt"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
+            }
+            catch (Exception ex)
+            {
+                if (stream != null)
+                {
+                    stream.Close();
+                    stream.Dispose();
+                }
+                throw ex;
             }
         }
     }

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/ErrorTesting.cs
@@ -130,6 +130,16 @@ namespace Frends.SFTP.UploadFiles.Tests
             var ex = Assert.Throws<Exception>(() => SFTP.UploadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.Contains("Error when fetching source files: File does not exist"));
         }
+
+        [Test]
+        public void UploadFiles_TestTransferThatThrowsWhenFileIsLocked()
+        {
+            using (var stream = File.OpenRead(Path.Combine(_workDir, "SFTPUploadTestFile1.txt")))
+            {
+                var ex = Assert.Throws<Exception>(() => SFTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken()));
+                Assert.IsFalse(ex.Message.Contains("Could not restore original source file"));
+            }
+        }
     }
 }
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -26,7 +26,7 @@ internal class FileTransporter
         _renamingPolicy = new RenamingPolicy(_batchContext.Info.TransferName, _instanceId);
 
         _result = new List<SingleFileTransferResult>();
-        _filePaths = (context.Source.FilePaths != null) ? ConvertObjectToStringArray(context.Source.FilePaths) : null;
+        _filePaths = (context.Source.FilePaths != null || !string.IsNullOrEmpty((string)context.Source.FilePaths)) ? ConvertObjectToStringArray(context.Source.FilePaths) : null;
 
         SourceDirectoryWithMacrosExtended = _renamingPolicy.ExpandDirectoryForMacros(context.Source.Directory);
         DestinationDirectoryWithMacrosExtended = _renamingPolicy.ExpandDirectoryForMacros(context.Destination.Directory);

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>2.5.3</Version>
+	  <Version>2.5.4</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#136 
- Fixed bug with task trying to rename the source file after exception without it being renamed in the first place.