### PR TITLE
SFTP.DownloadFiles - Fixed bug when FilePaths was used

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.6.1] - 2023-05-17
+### Fixed
+- Fixed issue with TransferredFileNames was incorrect when FilePaths parameter was used. 
+
 ## [2.6.0] - 2023-05-16
 ### Added
 - Added new result attribute TransferredDestinationFilePaths list consisting of the destination file paths.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -307,6 +307,8 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.AreEqual(3, result.SuccessfulTransferCount);
             Assert.IsTrue(result.Success);
+            Assert.AreNotEqual(filePaths[0], result.TransferredFileNames.ToList()[0]);
+            Assert.AreEqual(Path.GetFileName(filePaths[0]), result.TransferredFileNames.ToList()[0]);
         }
 
         [Test]

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -1,5 +1,6 @@
 ﻿using Renci.SshNet;
 using Renci.SshNet.Common;
+using Renci.SshNet.Sftp;
 using System.Net.Sockets;
 using System.Text;
 using System.Security.Cryptography;
@@ -386,15 +387,14 @@ internal class FileTransporter
 
         if (_filePaths != null)
         {
-            var items = _filePaths.Select(p => new FileItem(p) { Name = p }).ToList();
-            foreach (var file in items)
+            foreach (var file in _filePaths.ToList())
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (!client.Exists(file.FullPath))
-                    _logger.NotifyError(_batchContext, $"File does not exist: '{file.FullPath}", new FileNotFoundException());
+                if (!client.Exists(file))
+                    _logger.NotifyError(_batchContext, $"File does not exist: '{file}", new FileNotFoundException());
                 else
-                    fileItems.Add(file);
+                    fileItems.Add(new FileItem(client.Get(file)));
             }
 
             if (fileItems.Any()) return new Tuple<List<FileItem>, bool>(fileItems, true);

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -1,6 +1,5 @@
 ﻿using Renci.SshNet;
 using Renci.SshNet.Common;
-using Renci.SshNet.Sftp;
 using System.Net.Sockets;
 using System.Text;
 using System.Security.Cryptography;
@@ -287,7 +286,7 @@ internal class FileTransporter
                 prompt.Response = _batchContext.Connection.Password;
     }
 
-    private void ForceHostKeyAlgorithm(SftpClient client, HostKeyAlgorithms algorithm)
+    private static void ForceHostKeyAlgorithm(SftpClient client, HostKeyAlgorithms algorithm)
     {
         client.ConnectionInfo.HostKeyAlgorithms.Clear();
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.6.0</Version>
+	  <Version>2.6.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#143 
- Fixed issue with TransferredFileNames was incorrect when FilePaths parameter was used. 