### PR TITLE
SFTP.UploadFiles - Fixed issue with FilePaths parameter

### DIFF
--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.6.1] - 2023-05-17
+### Fixed
+- Fixed issue with TransferredFileNames was incorrect when FilePaths parameter was used. 
+
 ## [2.6.0] - 2023-05-16
 ### Added
 - Added new result attribute TransferredDestinationFilePaths list consisting of the file paths of destination files.

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.Tests/TransferTests.cs
@@ -308,6 +308,8 @@ namespace Frends.SFTP.UploadFiles.Tests
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.ActionSkipped);
             Assert.AreEqual(3, result.SuccessfulTransferCount);
+            Assert.AreNotEqual(filePaths[0], result.TransferredFileNames.ToList()[0]);
+            Assert.AreEqual(Path.GetFileName(filePaths[0]), result.TransferredFileNames.ToList()[0]);
         }
 
         [Test]

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -390,7 +390,7 @@ internal class FileTransporter
 
         if (_filePaths != null)
         {
-            fileItems = _filePaths.Select(p => new FileItem(p) { Name = p }).ToList();
+            fileItems = _filePaths.Select(p => new FileItem(p)).ToList();
             if (fileItems.Any())
                 return new Tuple<List<FileItem>, bool>(fileItems, true);
             return new Tuple<List<FileItem>, bool>(fileItems, false);

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>2.6.0</Version>
+	  <Version>2.6.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#145 
- Fixed issue with TransferredFileNames was incorrect when FilePaths parameter was used. 