### PR TITLE
SFTP.UploadFiles - Fixed issue with empty destination directory

### DIFF
--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -373,6 +373,22 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
+
+        [Test]
+        public void DownloadFiles_TestWithEmptySourceDirectory()
+        {
+            var source = new Source
+            {
+                Directory = "",
+                FileName = _source.FileName,
+                Action = SourceAction.Error,
+                Operation = SourceOperation.Nothing,
+            };
+
+            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            Assert.AreEqual(3, result.SuccessfulTransferCount);
+            Assert.IsTrue(result.Success);
+        }
     }
 }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -373,22 +373,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
-
-        [Test]
-        public void DownloadFiles_TestWithEmptySourceDirectory()
-        {
-            var source = new Source
-            {
-                Directory = "",
-                FileName = _source.FileName,
-                Action = SourceAction.Error,
-                Operation = SourceOperation.Nothing,
-            };
-
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
-            Assert.AreEqual(3, result.SuccessfulTransferCount);
-            Assert.IsTrue(result.Success);
-        }
     }
 }
 

--- a/Frends.SFTP.UploadFiles/CHANGELOG.md
+++ b/Frends.SFTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.7.2] - 2023-09-20
+### Fixed
+- Fixed issue with empty destination directory by adding forward slash to the parameter if it's empty.
+
 ## [2.7.1] - 2023-07-25
 ### Added
 - Added SFTPClient.OperationTimeout which should cause timeout during operations if the Task becomes stuck.

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -167,7 +167,7 @@ internal class FileTransporter
                     {
                         _cancellationToken.ThrowIfCancellationRequested();
 
-                        // Check that the connection is alive and if not try to connect again
+                        // Check that the connection is alive and if not try to connect again.
                         if (!client.IsConnected)
                             client.Connect();
 

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Definitions/FileTransporter.cs
@@ -34,7 +34,7 @@ internal class FileTransporter
         _filePaths = (context.Source.FilePaths != null || !string.IsNullOrEmpty((string)context.Source.FilePaths)) ? ConvertObjectToStringArray(context.Source.FilePaths) : null;
 
         SourceDirectoryWithMacrosExtended = _renamingPolicy.ExpandDirectoryForMacros(context.Source.Directory);
-        DestinationDirectoryWithMacrosExtended = _renamingPolicy.ExpandDirectoryForMacros(context.Destination.Directory);
+        DestinationDirectoryWithMacrosExtended = string.IsNullOrEmpty(context.Destination.Directory) ? "/" : _renamingPolicy.ExpandDirectoryForMacros(context.Destination.Directory);
     }
 
     private List<SingleFileTransferResult> _result { get; set; }

--- a/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
+++ b/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles/Frends.SFTP.UploadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.UploadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.UploadFiles</RootNamespace>
 
-	  <Version>2.7.1</Version>
+	  <Version>2.7.2</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#163 
- Fixed issue with empty destination directory by adding forward slash to the parameter if it's empty.