### PR TITLE
DownloadFiles - Fixed issue of Task getting in stuck

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.8.0] - 2023-12-05
+### Changed
+- [Breaking] Changed TransferredDestinationFilePaths Result property type from List to string[].
+- Changed SftpClient operations to use async methods with CancellationToken.
+### Added
+- Added FileOperations class which handles file operations as async with CancellationToken e.g. Append, Copy, Move.
+### Fixed
+- Fixed issue where the Task gets stuck and can't be terminated.
+
 ## [2.7.1] - 2023-09-08
 ### Added
 - Added SFTPClient.OperationTimeout which should cause timeout during operations if the Task becomes stuck.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/AppendTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/AppendTests.cs
@@ -1,6 +1,8 @@
 ﻿using NUnit.Framework;
+using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Frends.SFTP.DownloadFiles.Definitions;
 
 namespace Frends.SFTP.DownloadFiles.Tests
@@ -9,7 +11,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
     class AppendTests : DownloadFilesTestBase
     {
         [Test]
-        public void DownloadFiles_TestAppendToExistingFile()
+        public async Task DownloadFiles_TestAppendToExistingFile()
         {
             Directory.CreateDirectory(_destWorkDir);
             File.Copy(Path.Combine(_workDir, _source.FileName), Path.Combine(_destWorkDir, _source.FileName));
@@ -35,14 +37,14 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var result = SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var file2 = new FileInfo(Path.Combine(_destWorkDir, _source.FileName));
             Assert.AreNotEqual(file1.Length, file2.Length);
         }
 
         [Test]
-        public void DownloadFiles_AppendingToExistingFile()
+        public async Task DownloadFiles_AppendingToExistingFile()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -67,18 +69,19 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 EnableBomForContent = true
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content1 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
 
-            result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content2 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
             Assert.IsTrue(content2.Length > content1.Length);
+            Assert.AreEqual(content1 + Environment.NewLine + content1, content2);
         }
 
         [Test]
-        public void DownloadFiles_AppendingToExistingFileRenameSourceFile()
+        public async Task DownloadFiles_AppendingToExistingFileRenameSourceFile()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -102,18 +105,18 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileContentEncoding = FileEncoding.UTF8,
                 EnableBomForContent = true
             };
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content1 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
 
-            result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content2 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
             Assert.IsTrue(content2.Length > content1.Length);
         }
 
         [Test]
-        public void DownloadFiles_AppendingToExistingFileRenameDestinationFile()
+        public async Task DownloadFiles_AppendingToExistingFileRenameDestinationFile()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -137,18 +140,18 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileContentEncoding = FileEncoding.UTF8,
                 EnableBomForContent = true
             };
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content1 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
 
-            result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content2 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
             Assert.IsTrue(content2.Length > content1.Length);
         }
 
         [Test]
-        public void DownloadFiles_AppendingToExistingFileRenameBoth()
+        public async Task DownloadFiles_AppendingToExistingFileRenameBoth()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -173,18 +176,18 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 EnableBomForContent = true
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content1 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
 
-            result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content2 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
             Assert.IsTrue(content2.Length > content1.Length);
         }
 
         [Test]
-        public void DownloadFiles_AppendingToExistingFileRenameBothWithSourceFileNameStar()
+        public async Task DownloadFiles_AppendingToExistingFileRenameBothWithSourceFileNameStar()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -217,18 +220,18 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var result = SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content1 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
 
-            result = SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content2 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
             Assert.IsTrue(content2.Length > content1.Length);
         }
 
         [Test]
-        public void DownloadFiles_AppendWithoutNewLine()
+        public async Task DownloadFiles_AppendWithoutNewLine()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -261,11 +264,11 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var result = SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content1 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
 
-            result = SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content2 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
             Assert.IsTrue(content2.Length > content1.Length);

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Frends.SFTP.DownloadFiles.Definitions;
 
@@ -10,11 +11,12 @@ namespace Frends.SFTP.DownloadFiles.Tests
     public class ConnectivityTests : DownloadFilesTestBase
     {
         [Test]
-        public void DownloadFiles_TestWithLargerBuffer()
+        public async Task DownloadFiles_TestWithLargerBuffer()
         {
             Helpers.UploadLargeTestFiles(_source.Directory, 1);
 
             var connection = Helpers.GetSftpConnection();
+            connection.KeepAliveInterval = 10;
             connection.BufferSize = 256;
 
             var source = new Source
@@ -25,7 +27,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
@@ -38,25 +40,25 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.UserName = "demo";
             connection.Password = "demo";
 
-            var result = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+            var result = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(result.Message.StartsWith("SFTP transfer failed: Authentication of SSH session failed: Permission denied (password)"));
         }
 
         [Test]
-        public void DownloadFiles_TestPrivateKeyFileRsa()
+        public async Task DownloadFiles_TestPrivateKeyFileRsa()
         {
             var connection = Helpers.GetSftpConnection();
             connection.Authentication = AuthenticationType.UsernamePasswordPrivateKeyFile;
             connection.PrivateKeyPassphrase = "passphrase";
             connection.PrivateKeyFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../../Volumes/ssh_host_rsa_key");
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestPrivateKeyFileRsaFromString()
+        public async Task DownloadFiles_TestPrivateKeyFileRsaFromString()
         {
             var key = File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../../Volumes/ssh_host_rsa_key"));
 
@@ -66,24 +68,24 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.PrivateKeyPassphrase = "passphrase";
             connection.PrivateKeyString = key;
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestWithInteractiveKeyboardAuthentication()
+        public async Task DownloadFiles_TestWithInteractiveKeyboardAuthentication()
         {
             var connection = Helpers.GetSftpConnection();
             connection.UseKeyboardInteractiveAuthentication = true;
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestWithInteractiveKeyboardAuthenticationAndPrivateKey()
+        public async Task DownloadFiles_TestWithInteractiveKeyboardAuthenticationAndPrivateKey()
         {
             var connection = Helpers.GetSftpConnection();
             connection.Authentication = AuthenticationType.UsernamePrivateKeyFile;
@@ -93,7 +95,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.UseKeyboardInteractiveAuthentication = true;
             connection.PromptAndResponse = new PromptResponse[] { new PromptResponse { Prompt = "Password", Response = "pass" } };
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -110,13 +112,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 EnableBomForFileName = true
             };
 
-            result = SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestKeepAliveIntervalWithDefault()
+        public async Task DownloadFiles_TestKeepAliveIntervalWithDefault()
         {
             Helpers.UploadLargeTestFiles(_source.Directory, 1);
 
@@ -130,13 +132,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestKeepAliveIntervalWith1ms()
+        public async Task DownloadFiles_TestKeepAliveIntervalWith1ms()
         {
             Helpers.UploadLargeTestFiles(_source.Directory, 1);
 
@@ -152,7 +154,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/EncodingTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/EncodingTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Frends.SFTP.DownloadFiles.Definitions;
 
 namespace Frends.SFTP.DownloadFiles.Tests
@@ -9,13 +10,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
     class EncodingTests : DownloadFilesTestBase
     {
         [SetUp]
-        public void setup()
+        public void IndividualSetup()
         {
             Helpers.UploadTestFiles(_source.Directory, 3);
         }
 
         [Test]
-        public void UploadFiles_TransferWithANSIFileNameEncoding()
+        public async Task UploadFiles_TransferWithANSIFileNameEncoding()
         {
             var destination = new Destination
             {
@@ -23,13 +24,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameEncoding = FileEncoding.ANSI
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithASCIIFileNameEncoding()
+        public async Task UploadFiles_TransferWithASCIIFileNameEncoding()
         {
             var destination = new Destination
             {
@@ -37,13 +38,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameEncoding = FileEncoding.ASCII
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithUTF8WithoutBomFileNameEncoding()
+        public async Task UploadFiles_TransferWithUTF8WithoutBomFileNameEncoding()
         {
             var destination = new Destination
             {
@@ -52,13 +53,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 EnableBomForFileName = false
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithUTF8WithBomFileNameEncoding()
+        public async Task UploadFiles_TransferWithUTF8WithBomFileNameEncoding()
         {
             var destination = new Destination
             {
@@ -67,13 +68,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 EnableBomForFileName = true
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithWin1252FileNameEncoding()
+        public async Task UploadFiles_TransferWithWin1252FileNameEncoding()
         {
             var destination = new Destination
             {
@@ -81,13 +82,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameEncoding = FileEncoding.WINDOWS1252
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithOtherFileNameEncoding()
+        public async Task UploadFiles_TransferWithOtherFileNameEncoding()
         {
             var destination = new Destination
             {
@@ -96,13 +97,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameEncodingInString = "windows-1252"
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithASCIIFileContentEncoding()
+        public async Task UploadFiles_TransferWithASCIIFileContentEncoding()
         {
             var destination = new Destination
             {
@@ -114,13 +115,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Directory.CreateDirectory(destination.Directory);
             File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithANSIFileContentEncoding()
+        public async Task UploadFiles_TransferWithANSIFileContentEncoding()
         {
             var destination = new Destination
             {
@@ -132,13 +133,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Directory.CreateDirectory(destination.Directory);
             File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithUTF8WithBomFileContentEncoding()
+        public async Task UploadFiles_TransferWithUTF8WithBomFileContentEncoding()
         {
             var destination = new Destination
             {
@@ -151,13 +152,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Directory.CreateDirectory(destination.Directory);
             File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithUTF8WithoutBomFileContentEncoding()
+        public async Task UploadFiles_TransferWithUTF8WithoutBomFileContentEncoding()
         {
             var destination = new Destination
             {
@@ -170,13 +171,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Directory.CreateDirectory(destination.Directory);
             File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithWIN1252FileContentEncoding()
+        public async Task UploadFiles_TransferWithWIN1252FileContentEncoding()
         {
             var destination = new Destination
             {
@@ -188,13 +189,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Directory.CreateDirectory(destination.Directory);
             File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void UploadFiles_TransferWithOtherFileContentEncoding()
+        public async Task UploadFiles_TransferWithOtherFileContentEncoding()
         {
             var destination = new Destination
             {
@@ -207,7 +208,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Directory.CreateDirectory(destination.Directory);
             File.Move(Path.Combine(_workDir, _source.FileName), Path.Combine(_destination.Directory, _source.FileName));
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
@@ -15,7 +15,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Directory.CreateDirectory(_destWorkDir);
             File.Copy(Path.Combine(_workDir, _source.FileName), Path.Combine(_destWorkDir, _source.FileName));
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, _connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, _connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith($"SFTP transfer failed: 1 Errors: Failure in CheckIfDestination"));
         }
 
@@ -30,7 +30,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: 1 Errors: No source files found from directory"));
         }
 
@@ -40,7 +40,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var connection = Helpers.GetSftpConnection();
             connection.Port = 51651;
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Unable to establish the socket: No such host is known"));
         }
 
@@ -57,7 +57,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: 1 Errors: No source files found from directory"));
             Helpers.DeleteSubDirectory(path);
         }
@@ -76,7 +76,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 DirectoryToMoveAfterTransfer = "/upload/test"
             };
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.Contains($"Operation failed: Source file {_source.FileName} couldn't be moved to given directory {source.DirectoryToMoveAfterTransfer} because the directory didn't exist."));
             Assert.IsTrue(Helpers.SourceFileExists(_source.Directory + "/" + _source.FileName));
         }
@@ -115,7 +115,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Action = DestinationAction.Error,
             };
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith($"SFTP transfer failed: 1 Errors: Failure in CheckIfDestination"));
             Assert.IsTrue(Helpers.SourceFileExists(Path.Combine(_source.Directory, _source.FileName).Replace("\\", "/")));
         }
@@ -144,7 +144,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Action = DestinationAction.Error,
             };
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith($"SFTP transfer failed: 1 Errors: Failure in CheckIfDestination"));
             Assert.IsTrue(Helpers.SourceFileExists(Path.Combine(_source.Directory, _source.FileName).Replace("\\", "/")));
         }
@@ -155,7 +155,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var connection = Helpers.GetSftpConnection();
             connection.Password = "cuinbeu8i9ch";
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.Contains($"SFTP transfer failed: Authentication of SSH session failed: Permission denied (password)"));
         }
     }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/MacroTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/MacroTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Frends.SFTP.DownloadFiles.Definitions;
 
 namespace Frends.SFTP.DownloadFiles.Tests
@@ -11,7 +12,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
     internal class MacroTests : DownloadFilesTestBase
     {
         [Test]
-        public void DownloadFiles_TestUsingMacros()
+        public async Task DownloadFiles_TestUsingMacros()
         {
             var destination = new Destination
             {
@@ -20,7 +21,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Action = DestinationAction.Error,
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var date = DateTime.Now;
             var file = Path.Combine(_destWorkDir, "SFTPDownloadTestFile1" + date.ToString(@"yyyy-MM-dd") + ".txt");
@@ -29,7 +30,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSourceDirectoryWithMacros()
+        public async Task DownloadFiles_TestSourceDirectoryWithMacros()
         {
             Helpers.UploadTestFiles(_source.Directory + "/testfolder_" + DateTime.Now.Year, 3);
 
@@ -41,14 +42,14 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
         }
 
         [Test]
-        public void DownloadFiles_TestDestinationDirectoryWithMacros()
+        public async Task DownloadFiles_TestDestinationDirectoryWithMacros()
         {
             var year = DateTime.Now.Year.ToString();
             var destination = new Destination
@@ -60,7 +61,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Action = DestinationAction.Error,
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -71,7 +72,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSourceFileRenameWithMacros()
+        public async Task DownloadFiles_TestSourceFileRenameWithMacros()
         {
             var year = DateTime.Now.Year.ToString();
             var to = "/upload/Upload/" + year + "_uploaded/" + Path.GetFileNameWithoutExtension(_source.FileName) + year + Path.GetExtension(_source.FileName);
@@ -86,7 +87,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameAfterTransfer = to,
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -94,7 +95,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSourceFileRenameWithMacros2()
+        public async Task DownloadFiles_TestSourceFileRenameWithMacros2()
         {
             var source = new Source
             {
@@ -105,7 +106,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameAfterTransfer = "uploaded_%SourceFileName%%SourceFileExtension%"
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -113,7 +114,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSourceFileMoveWithMacros()
+        public async Task DownloadFiles_TestSourceFileMoveWithMacros()
         {
             var year = DateTime.Now.Year.ToString();
             var to = $"/upload/Upload/{year}_uploaded";
@@ -128,7 +129,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 DirectoryToMoveAfterTransfer = "/upload/Upload/%Year%_uploaded"
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/PreserveModifiedTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/PreserveModifiedTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Frends.SFTP.DownloadFiles.Definitions;
 
 namespace Frends.SFTP.DownloadFiles.Tests
@@ -42,9 +43,9 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestPreserveLastModifiedWithoutRename()
+        public async Task DownloadFiles_TestPreserveLastModifiedWithoutRename()
         {
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             var destFilePath = Path.Combine(destination.Directory, _source.FileName);
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
@@ -54,12 +55,12 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestPreserveLastModifiedWithRename()
+        public async Task DownloadFiles_TestPreserveLastModifiedWithRename()
         {
             options.RenameSourceFileBeforeTransfer = true;
             options.RenameDestinationFileDuringTransfer = true;
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             var destFilePath = Path.Combine(destination.Directory, _source.FileName);
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
@@ -69,12 +70,12 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestPreserveLastModifiedWithSourceRename()
+        public async Task DownloadFiles_TestPreserveLastModifiedWithSourceRename()
         {
             options.RenameSourceFileBeforeTransfer = true;
             options.RenameDestinationFileDuringTransfer = false;
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             var destFilePath = Path.Combine(destination.Directory, _source.FileName);
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
@@ -84,12 +85,12 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestPreserveLastModifiedWithDestinationRename()
+        public async Task DownloadFiles_TestPreserveLastModifiedWithDestinationRename()
         {
             options.RenameSourceFileBeforeTransfer = false;
             options.RenameDestinationFileDuringTransfer = true;
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             var destFilePath = Path.Combine(destination.Directory, _source.FileName);
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
@@ -99,7 +100,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestPreserveLastModifiedWithRenameAndDeleteSourceFile()
+        public async Task DownloadFiles_TestPreserveLastModifiedWithRenameAndDeleteSourceFile()
         {
             options.RenameSourceFileBeforeTransfer = true;
             options.RenameDestinationFileDuringTransfer = true;
@@ -112,7 +113,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Delete,
             };
 
-            var result = SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
             var destFilePath = Path.Combine(destination.Directory, _source.FileName);
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ServerFingerprintTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ServerFingerprintTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Frends.SFTP.DownloadFiles.Definitions;
 
@@ -31,79 +32,79 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsHexSha256()
+        public async Task DownloadFiles_TestTransferWithExpectedServerFingerprintAsHexSha256()
         {
             var connection = Helpers.GetSftpConnection();
             connection.ServerFingerPrint = _Sha256Hex;
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.ActionSkipped);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsHexSha256WithAltercations()
+        public async Task DownloadFiles_TestTransferWithExpectedServerFingerprintAsHexSha256WithAltercations()
         {
             var connection = Helpers.GetSftpConnection();
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
             connection.ServerFingerPrint = _Sha256Hash.Replace("=", "");
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.ActionSkipped);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsSha256()
+        public async Task DownloadFiles_TestTransferWithExpectedServerFingerprintAsSha256()
         {
             var connection = Helpers.GetSftpConnection();
             connection.ServerFingerPrint = _Sha256Hash;
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.ActionSkipped);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5()
+        public async Task DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5()
         {
             var connection = Helpers.GetSftpConnection();
             connection.ServerFingerPrint = _MD5;
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.ActionSkipped);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5ToLower()
+        public async Task DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5ToLower()
         {
             var connection = Helpers.GetSftpConnection();
             connection.ServerFingerPrint = _MD5.ToLower();
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.ActionSkipped);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5Hash()
+        public async Task DownloadFiles_TestTransferWithExpectedServerFingerprintAsMD5Hash()
         {
             var connection = Helpers.GetSftpConnection();
             connection.ServerFingerPrint = _MD5.Replace(":", "");
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var result = SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.ActionSkipped);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
@@ -116,7 +117,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.ServerFingerPrint = "73:58:DF:2D:CD:12:35:AB:7D:00:41:F0:1E:62:15:E0";
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
         }
 
@@ -127,7 +128,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.ServerFingerPrint = "c4b56fba6167c11f62e26b192c839d394e5c8d278b614b81345d037d178442f2";
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
         }
 
@@ -138,7 +139,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.ServerFingerPrint = "nuDEsWN4tfEQ684+x+7RySiCwj+GXmX2CfBaBHeSqO8=";
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
         }
 
@@ -149,7 +150,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.ServerFingerPrint = "nuDEsWN4tfEQ684x7RySiCwjGXmX2CfBaBHeSqO8vfiurenvire56";
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Error when establishing connection to the Server: Key exchange negotiation failed.."));
             Assert.IsTrue(ex.Message.Contains("Expected server fingerprint was given in unsupported format."));
         }
@@ -166,7 +167,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             connection.HostKeyAlgorithm = HostKeyAlgorithms.RSA;
             connection.ServerFingerPrint = _Sha256Hash.Replace("=", "");
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Failure in Keyboard-interactive authentication: No response given for server prompt request --> Password"));
 
             connection.Authentication = AuthenticationType.UsernamePrivateKeyString;
@@ -182,7 +183,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 EnableBomForFileName = true
             };
 
-            ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken()));
+            ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.StartsWith("SFTP transfer failed: Failure in Keyboard-interactive authentication: No response given for server prompt request --> Password"));
         }
     }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/SourceOperationTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/SourceOperationTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Frends.SFTP.DownloadFiles.Definitions;
 
 namespace Frends.SFTP.DownloadFiles.Tests
@@ -9,7 +10,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
     class SourceOperationTests : DownloadFilesTestBase
     {
         [Test]
-        public void DownloadFiles_SourceOperationNothingWithRenamingDisable()
+        public async Task DownloadFiles_SourceOperationNothingWithRenamingDisable()
         {
             var options = new Options
             {
@@ -20,14 +21,14 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 PreserveLastModified = false,
                 OperationLog = true
             };
-            var result = SFTP.DownloadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
 
             Assert.IsTrue(Helpers.SourceFileExists(_source.Directory + "/" + _source.FileName));
         }
 
         [Test]
-        public void DownloadFiles_TestSourceOperationMove()
+        public async Task DownloadFiles_TestSourceOperationMove()
         {
             var to = "uploaded";
             Helpers.UploadTestFiles(_source.Directory, 1, to);
@@ -41,7 +42,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 DirectoryToMoveAfterTransfer = to
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -49,7 +50,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestWithSourceMoveToNonExistingDirectoryShouldReturnUnsuccessfulTransfer()
+        public async Task DownloadFiles_TestWithSourceMoveToNonExistingDirectoryShouldReturnUnsuccessfulTransfer()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -72,13 +73,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 DirectoryToMoveAfterTransfer = "/upload/test"
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsFalse(result.Success);
             Assert.IsTrue(Helpers.SourceFileExists(Path.Combine(_source.Directory, _source.FileName).Replace("\\", "/")));
         }
 
         [Test]
-        public void DownloadFiles_TestSourceOperationRename()
+        public async Task DownloadFiles_TestSourceOperationRename()
         {
             var source = new Source
             {
@@ -89,7 +90,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameAfterTransfer = "uploaded_%SourceFileName%.txt"
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -97,7 +98,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSourceOperationMoveWithRenameFilesDuringTransfer()
+        public async Task DownloadFiles_TestSourceOperationMoveWithRenameFilesDuringTransfer()
         {
             var to = "uploaded";
             Helpers.UploadTestFiles(_source.Directory, 3, to);
@@ -122,7 +123,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 DirectoryToMoveAfterTransfer = to
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -130,7 +131,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSourceOperationRenameWithRenameFilesDuringTransfer()
+        public async Task DownloadFiles_TestSourceOperationRenameWithRenameFilesDuringTransfer()
         {
             var options = new Options
             {
@@ -151,7 +152,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameAfterTransfer = "uploaded_%SourceFileName%.txt"
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -159,7 +160,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSourceOperationMoveWithRenameFilesDuringTransferWithRenameSourceAndDestinationFilesEnabled()
+        public async Task DownloadFiles_TestSourceOperationMoveWithRenameFilesDuringTransferWithRenameSourceAndDestinationFilesEnabled()
         {
             var to = "uploaded";
             Helpers.UploadTestFiles(_source.Directory, 3, to);
@@ -184,7 +185,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 DirectoryToMoveAfterTransfer = to
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -192,7 +193,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSourceOperationRenameWithRenameFilesDuringTransferWithRenameSourceAndDestinationFilesEnabled()
+        public async Task DownloadFiles_TestSourceOperationRenameWithRenameFilesDuringTransferWithRenameSourceAndDestinationFilesEnabled()
         {
             var options = new Options
             {
@@ -213,7 +214,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameAfterTransfer = "uploaded_%SourceFileName%.txt"
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -221,7 +222,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_SourceOperationDelete()
+        public async Task DownloadFiles_SourceOperationDelete()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -243,13 +244,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Delete
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(Helpers.SourceFileExists(_source.Directory + "/" + _source.FileName));
         }
 
         [Test]
-        public void DownloadFiles_SourceOperationDeleteRenameSourceFile()
+        public async Task DownloadFiles_SourceOperationDeleteRenameSourceFile()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -271,13 +272,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Delete
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(Helpers.SourceFileExists(_source.Directory + "/" + _source.FileName));
         }
 
         [Test]
-        public void DownloadFiles_SourceOperationDeleteRenameDestinationFile()
+        public async Task DownloadFiles_SourceOperationDeleteRenameDestinationFile()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -299,13 +300,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Delete
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(Helpers.SourceFileExists(_source.Directory + "/" + _source.FileName));
         }
 
         [Test]
-        public void DownloadFiles_SourceOperationDeleteRenameBoth()
+        public async Task DownloadFiles_SourceOperationDeleteRenameBoth()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -327,13 +328,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Delete
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.IsFalse(Helpers.SourceFileExists(_source.Directory + "/" + _source.FileName));
         }
 
         [Test]
-        public void DownloadFiles_TestSourceOperationRenameWithDifferentDirectory()
+        public async Task DownloadFiles_TestSourceOperationRenameWithDifferentDirectory()
         {
             Helpers.CreateSubDirectory("upload/moved");
 
@@ -346,7 +347,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FileNameAfterTransfer = "upload/moved/uploaded_%SourceFileName%.txt"
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using Frends.SFTP.DownloadFiles.Definitions;
 
@@ -12,9 +13,9 @@ namespace Frends.SFTP.DownloadFiles.Tests
     class TransferTests : DownloadFilesTestBase
     {
         [Test]
-        public void DownloadFiles_TestSimpleTransfer()
+        public async Task DownloadFiles_TestSimpleTransfer()
         {
-            var result = SFTP.DownloadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
             Assert.AreEqual(Path.Combine(_destination.Directory, _source.FileName), result.TransferredDestinationFilePaths.ToList().FirstOrDefault());
@@ -31,12 +32,12 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = _source.Operation,
             };
 
-            var ex = Assert.Throws<Exception>(() => SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
+            var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken()));
             Assert.IsTrue(ex.Message.Contains("No source"));
         }
 
         [Test]
-        public void DownloadFiles_TestDownloadWithFileMask()
+        public async Task DownloadFiles_TestDownloadWithFileMask()
         {
             var source = new Source
             {
@@ -46,13 +47,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(3, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestWithOperationLogDisabled()
+        public async Task DownloadFiles_TestWithOperationLogDisabled()
         {
             var options = new Options
             {
@@ -64,13 +65,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 OperationLog = false
             };
 
-            var result = SFTP.DownloadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(0, result.OperationsLog.Count);
         }
 
         [Test]
-        public void DownloadFiles_TestWithMultipleSubdirectoriesInDestination()
+        public async Task DownloadFiles_TestWithMultipleSubdirectoriesInDestination()
         {
             var destination = new Destination
             {
@@ -78,14 +79,14 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Action = DestinationAction.Error,
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
             Assert.IsTrue(File.Exists(Path.Combine(destination.Directory, _source.FileName)));
         }
 
         [Test]
-        public void DownloadFiles_TestOneErrorInTransferWithMultipleFiles()
+        public async Task DownloadFiles_TestOneErrorInTransferWithMultipleFiles()
         {
             Directory.CreateDirectory(_destWorkDir);
             File.Copy(Path.Combine(_workDir, _source.FileName), Path.Combine(_destWorkDir, _source.FileName));
@@ -116,7 +117,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing
             };
 
-            var result = SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsFalse(result.Success);
             Assert.AreEqual(2, result.SuccessfulTransferCount);
             Assert.AreEqual(1, result.FailedTransferCount);
@@ -124,7 +125,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestSingleFileTransferWithError()
+        public async Task DownloadFiles_TestSingleFileTransferWithError()
         {
             var options = new Options
             {
@@ -139,13 +140,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
             Directory.CreateDirectory(_destWorkDir);
             File.Copy(Path.Combine(_workDir, _source.FileName), Path.Combine(_destWorkDir, _source.FileName));
 
-            var result = SFTP.DownloadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsFalse(result.Success);
             Assert.AreEqual(1, result.FailedTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestWithFileMaskWithFileAlreadyInDestination()
+        public async Task DownloadFiles_TestWithFileMaskWithFileAlreadyInDestination()
         {
             var source = new Source
             {
@@ -165,19 +166,19 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 OperationLog = true
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
             source.FileName = "*.txt";
-            result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsFalse(result.Success);
             Assert.AreEqual(1, result.FailedTransferCount);
             Assert.AreEqual(2, result.SuccessfulTransferCount);
         }
 
         [Test]
-        public void DownloadFiles_TestDownloadWithOverwrite()
+        public async Task DownloadFiles_TestDownloadWithOverwrite()
         {
             var destination = new Destination
             {
@@ -185,7 +186,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Action = DestinationAction.Overwrite,
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -193,7 +194,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestTransferWithRenameSourceEnabledRenameDestinationDisabled()
+        public async Task DownloadFiles_TestTransferWithRenameSourceEnabledRenameDestinationDisabled()
         {
             var destination = new Destination
             {
@@ -211,7 +212,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 OperationLog = true
             };
 
-            var result = SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -219,7 +220,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_NoSourceFilesAndIgnoreShouldNotThrowException()
+        public async Task DownloadFiles_NoSourceFilesAndIgnoreShouldNotThrowException()
         {
             Helpers.CreateSubDirectory("/upload/Upload");
             var options = new Options
@@ -240,14 +241,14 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Delete
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.ActionSkipped);
             Assert.IsFalse(result.UserResultMessage.Contains("1 files transferred"));
             Assert.IsTrue(result.UserResultMessage.Contains("No files transferred"));
         }
 
         [Test]
-        public void DownloadFiles_NoSourceFilesAndInfoShouldNotThrowException()
+        public async Task DownloadFiles_NoSourceFilesAndInfoShouldNotThrowException()
         {
             Helpers.CreateSubDirectory("/upload/Upload");
             var options = new Options
@@ -268,14 +269,14 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Delete
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.ActionSkipped);
             Assert.IsFalse(result.UserResultMessage.Contains("1 files transferred"));
             Assert.IsTrue(result.UserResultMessage.Contains("No files transferred"));
         }
 
         [Test]
-        public void DownloadFiles_TestNoSourceShouldNotCreateOperationsLogWhenSourceActionIsIgnore()
+        public async Task DownloadFiles_TestNoSourceShouldNotCreateOperationsLogWhenSourceActionIsIgnore()
         {
             Directory.CreateDirectory(_destWorkDir);
 
@@ -287,13 +288,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(0, result.OperationsLog.Count);
         }
 
         [Test]
-        public void DownloadFiles_TestWithFilePaths()
+        public async Task DownloadFiles_TestWithFilePaths()
         {
             var filePaths = Helpers.UploadTestFiles(_source.Directory, 3);
 
@@ -304,7 +305,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FilePaths = filePaths
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.AreEqual(3, result.SuccessfulTransferCount);
             Assert.IsTrue(result.Success);
             Assert.AreNotEqual(filePaths[0], result.TransferredFileNames.ToList()[0]);
@@ -312,7 +313,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public void DownloadFiles_TestWitFilePathsEvenIfSourceFileIsAssigned()
+        public async Task DownloadFiles_TestWitFilePathsEvenIfSourceFileIsAssigned()
         {
             var filePaths = Helpers.UploadTestFiles(_source.Directory, 3);
 
@@ -325,13 +326,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 FilePaths = filePaths
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.AreEqual(3, result.SuccessfulTransferCount);
             Assert.IsTrue(result.Success);
         }
 
         [Test]
-        public void DownloadFiles_TestTransferWithSpecialCharactersInFileNames()
+        public async Task DownloadFiles_TestTransferWithSpecialCharactersInFileNames()
         {
             // upload test files
             var files = new List<string> { "this is a test file.txt", "This_is(a test file).txt", "this is  { a test} file.txt" };
@@ -345,7 +346,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            var result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -357,7 +358,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
 
@@ -369,7 +370,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 Operation = SourceOperation.Nothing,
             };
 
-            result = SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -313,7 +313,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
 
         [Test]
-        public async Task DownloadFiles_TestWitFilePathsEvenIfSourceFileIsAssigned()
+        public async Task DownloadFiles_TestWithFilePathsEvenIfSourceFileIsAssigned()
         {
             var filePaths = Helpers.UploadTestFiles(_source.Directory, 3);
 
@@ -329,6 +329,46 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
             Assert.AreEqual(3, result.SuccessfulTransferCount);
             Assert.IsTrue(result.Success);
+        }
+
+        [Test]
+        public async Task DownloadFiles_TestWithEmptyFilePathsShouldNotThrow()
+        {
+            var filePaths = Array.Empty<string>();
+
+            var source = new Source
+            {
+                Directory = "/",
+                FileName = string.Empty,
+                Action = SourceAction.Info,
+                Operation = SourceOperation.Nothing,
+                FilePaths = filePaths
+            };
+
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            Assert.AreEqual(0, result.SuccessfulTransferCount);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.ActionSkipped);
+        }
+
+        [Test]
+        public async Task DownloadFiles_TestWithFileNotFoundInFilePaths()
+        {
+            var filePaths = new string[] { "/upload/fileThatdontexists.txt" };
+
+            var source = new Source
+            {
+                Directory = "/",
+                FileName = string.Empty,
+                Action = SourceAction.Info,
+                Operation = SourceOperation.Nothing,
+                FilePaths = filePaths
+            };
+
+            var result = await SFTP.DownloadFiles(source, _destination, _connection, _options, _info, new CancellationToken());
+            Assert.AreEqual(0, result.SuccessfulTransferCount);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.ActionSkipped);
         }
 
         [Test]

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Connection.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Connection.cs
@@ -140,5 +140,5 @@ public class Connection
     /// Responses for the server prompts when using Keyboard Interactive authentication method.
     /// </summary>
     [UIHint(nameof(UseKeyboardInteractiveAuthentication), "", true)]
-    public PromptResponse[] PromptAndResponse { get; set; } = new PromptResponse[0];
+    public PromptResponse[] PromptAndResponse { get; set; } = Array.Empty<PromptResponse>();
 }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileItem.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileItem.cs
@@ -12,7 +12,7 @@ internal class FileItem
 
     public long Size { get; set; }
 
-    public FileItem(SftpFile file)
+    public FileItem(ISftpFile file)
     {
         Modified = file.LastWriteTime;
         Name = file.Name;

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileOperations.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileOperations.cs
@@ -1,0 +1,60 @@
+﻿namespace Frends.SFTP.DownloadFiles.Definitions
+{
+    internal class FileOperations
+    {
+        internal static async Task AppendAsync(string source, string remoteFile, bool addNewLine, CancellationToken cancellationToken)
+        {
+            if (addNewLine)
+            {
+                using (var stream = File.Open(remoteFile, FileMode.Open, FileAccess.ReadWrite))
+                using (var reader = new StreamReader(stream))
+                using (var writer = new StreamWriter(stream))
+                {
+                    // Determines if there is a new line at the end of the file. If not, one is appended.
+                    long readPosition = stream.Length == 0 ? 0 : -1;
+                    stream.Seek(readPosition, SeekOrigin.End);
+                    string end = reader.ReadToEnd();
+                    if (end.Length != 0 && !end.Equals(Environment.NewLine, StringComparison.Ordinal))
+                    {
+                        writer.Write(Environment.NewLine);
+                    }
+                    writer.Flush();
+                }
+            }
+
+            using (var srcStream = new FileStream(source, FileMode.Open, FileAccess.Read))
+            {
+                using (var outStream = new FileStream(remoteFile, FileMode.Append, FileAccess.Write))
+                {
+                    byte[] buff = new byte[4096];
+                    int r;
+                    while ((r = await srcStream.ReadAsync(buff, 0, buff.Length, cancellationToken)) != 0)
+                    {
+                        await outStream.WriteAsync(buff, 0, r, cancellationToken);
+                    }
+                    outStream.Flush();
+                }
+            }
+        }
+            
+
+        internal static async Task CopyAsync(string source, string remoteFile, bool overwrite, CancellationToken cancellationToken)
+        {
+            FileMode fileMode = overwrite ? FileMode.Create : FileMode.CreateNew;
+
+            using (Stream sourceStream = new FileStream(source, FileMode.Open, FileAccess.Read))
+            {
+                using (Stream destinationStream = new FileStream(remoteFile, fileMode, FileAccess.Write))
+                {
+                    await sourceStream.CopyToAsync(destinationStream, bufferSize: 81920, cancellationToken);
+                }
+            }
+        }
+
+        internal static async Task MoveAsync(string source, string remoteFile, CancellationToken cancellationToken)
+        {
+            await CopyAsync(source, remoteFile, false, cancellationToken);
+            File.Delete(source);
+        }
+    }
+}

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransferResult.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransferResult.cs
@@ -18,7 +18,7 @@ internal class FileTransferResult
 
     public IEnumerable<string> TransferredFilePaths { get; set; }
 
-    public IEnumerable<string> TransferredDestinationFilePaths { get; set; }
+    public string[] TransferredDestinationFilePaths { get; set; }
 
     public IDictionary<string, string> OperationsLog { get; set; }
 }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -1,5 +1,7 @@
 ﻿using Renci.SshNet;
 using Renci.SshNet.Common;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Sockets;
 using System.Reflection;
@@ -20,17 +22,20 @@ internal class FileTransporter
     private readonly BatchContext _batchContext;
     private readonly string[] _filePaths;
     private readonly RenamingPolicy _renamingPolicy;
-    private readonly CancellationToken _cancellationToken;
+    private List<SingleFileTransferResult> Result { get; set; }
 
-    internal FileTransporter(ISFTPLogger logger, BatchContext context, Guid instanceId, CancellationToken cancellationToken)
+    private string SourceDirectoryWithMacrosExtended { get; set; }
+
+    private string DestinationDirectoryWithMacrosExtended { get; set; }
+
+    internal FileTransporter(ISFTPLogger logger, BatchContext context, Guid instanceId)
     {
         _logger = logger;
         _batchContext = context;
         _instanceId = instanceId;
         _renamingPolicy = new RenamingPolicy(_batchContext.Info.TransferName, _instanceId);
-        _cancellationToken = cancellationToken;
 
-        _result = new List<SingleFileTransferResult>();
+        Result = new List<SingleFileTransferResult>();
         _filePaths = ConvertObjectToStringArray(context.Source.FilePaths);
 
         if (_filePaths == null || !_filePaths.Any())
@@ -39,12 +44,6 @@ internal class FileTransporter
         DestinationDirectoryWithMacrosExtended = _renamingPolicy.ExpandDirectoryForMacros(context.Destination.Directory);
     }
 
-    private List<SingleFileTransferResult> _result { get; set; }
-
-    private string SourceDirectoryWithMacrosExtended { get; set; }
-
-    private string DestinationDirectoryWithMacrosExtended { get; set; }
-
     /// <summary>
     /// Executes file transfers.
     /// </summary>
@@ -52,7 +51,7 @@ internal class FileTransporter
     /// <exception cref="DirectoryNotFoundException"></exception>
     /// <exception cref="FileNotFoundException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public FileTransferResult Run()
+    public async Task<FileTransferResult> Run(CancellationToken cancellationToken)
     {
         _logger.NotifyInformation(_batchContext, $"Connecting to {_batchContext.Connection.Address}:{_batchContext.Connection.Port} using SFTP.");
 
@@ -78,97 +77,105 @@ internal class FileTransporter
 
             using (var client = new SftpClient(connectionInfo))
             {
-                if (_batchContext.Connection.HostKeyAlgorithm != HostKeyAlgorithms.Any)
-                    ForceHostKeyAlgorithm(client, _batchContext.Connection.HostKeyAlgorithm);
-
-                var expectedServerFingerprint = _batchContext.Connection.ServerFingerPrint;
-
                 try
                 {
-                    CheckServerFingerprint(client, expectedServerFingerprint);
-                }
-                catch (Exception e)
-                {
-                    _logger.NotifyError(null, $"Error when checking the server fingerprint", e);
-                    return FormFailedFileTransferResult(userResultMessage);
-                }
+                    if (_batchContext.Connection.HostKeyAlgorithm != HostKeyAlgorithms.Any)
+                        ForceHostKeyAlgorithm(client, _batchContext.Connection.HostKeyAlgorithm);
 
-                client.ConnectionInfo.Timeout = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout);
-                client.KeepAliveInterval = TimeSpan.FromMilliseconds(_batchContext.Connection.KeepAliveInterval);
-                client.OperationTimeout = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout);
+                    var expectedServerFingerprint = _batchContext.Connection.ServerFingerPrint;
 
-                client.BufferSize = _batchContext.Connection.BufferSize * 1024;
-
-                client.Connect();
-
-                if (!client.IsConnected)
-                {
-                    _logger.NotifyError(null, "Error while connecting to destination: ", new SshConnectionException(userResultMessage));
-                    return FormFailedFileTransferResult(userResultMessage);
-                }
-
-                _logger.NotifyInformation(_batchContext, "Negotiation finished.");
-
-                // Fetch source file info and check if files were returned.
-                var (files, success) = ListSourceFiles(client, _batchContext.Source, _cancellationToken);
-
-                // If source directory doesn't exist, modify userResultMessage accordingly.
-                if (!success)
-                {
-                    userResultMessage = $"Directory '{SourceDirectoryWithMacrosExtended}' doesn't exists.";
-                    _logger.NotifyInformation(_batchContext, userResultMessage);
-                    return FormFailedFileTransferResult(userResultMessage);
-                }
-
-                if (files.Count == 0)
-                {
-                    if (files == null)
-                        _logger.NotifyInformation(_batchContext,
-                            "Source end point returned null list for file list. If there are no files to transfer, the result should be an empty list.");
-
-                    var noSourceResult = NoSourceOperation(_batchContext, _batchContext.Source);
-                    _result.Add(noSourceResult);
-                }
-                else
-                {
-
-                    // Check does the destination directory exists.
-                    if (!Directory.Exists(DestinationDirectoryWithMacrosExtended))
+                    try
                     {
-                        if (_batchContext.Options.CreateDestinationDirectories)
+                        CheckServerFingerprint(client, expectedServerFingerprint);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.NotifyError(null, $"Error when checking the server fingerprint", e);
+                        return FormFailedFileTransferResult(userResultMessage);
+                    }
+
+                    client.ConnectionInfo.Timeout = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout);
+                    client.KeepAliveInterval = TimeSpan.FromMilliseconds(_batchContext.Connection.KeepAliveInterval);
+                    client.OperationTimeout = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout);
+
+                    _batchContext.Connection.BufferSize = _batchContext.Connection.BufferSize * 1024;
+                    client.BufferSize = _batchContext.Connection.BufferSize;
+
+                    await client.ConnectAsync(cancellationToken);
+
+                    if (!client.IsConnected)
+                    {
+                        _logger.NotifyError(null, "Error while connecting to destination: ", new SshConnectionException(userResultMessage));
+                        return FormFailedFileTransferResult(userResultMessage);
+                    }
+
+                    _logger.NotifyInformation(_batchContext, "Negotiation finished.");
+
+                    // Fetch source file info and check if files were returned.
+                    var (files, success) = ListSourceFiles(client, _batchContext.Source, cancellationToken);
+
+                    // If source directory doesn't exist, modify userResultMessage accordingly.
+                    if (!success)
+                    {
+                        userResultMessage = $"Directory '{SourceDirectoryWithMacrosExtended}' doesn't exists.";
+                        _logger.NotifyInformation(_batchContext, userResultMessage);
+                        return FormFailedFileTransferResult(userResultMessage);
+                    }
+
+                    if (files.Count == 0)
+                    {
+                        if (files == null)
+                            _logger.NotifyInformation(_batchContext,
+                                "Source end point returned null list for file list. If there are no files to transfer, the result should be an empty list.");
+
+                        var noSourceResult = NoSourceOperation(_batchContext, _batchContext.Source);
+                        Result.Add(noSourceResult);
+                    }
+                    else
+                    {
+
+                        // Check does the destination directory exists.
+                        if (!Directory.Exists(DestinationDirectoryWithMacrosExtended))
                         {
-                            try
+                            if (_batchContext.Options.CreateDestinationDirectories)
                             {
-                                Directory.CreateDirectory(DestinationDirectoryWithMacrosExtended);
+                                try
+                                {
+                                    Directory.CreateDirectory(DestinationDirectoryWithMacrosExtended);
+                                }
+                                catch (Exception ex)
+                                {
+                                    userResultMessage = $"Error while creating destination directory '{DestinationDirectoryWithMacrosExtended}': {ex.Message}";
+                                    return FormFailedFileTransferResult(userResultMessage);
+                                }
                             }
-                            catch (Exception ex)
+                            else
                             {
-                                userResultMessage = $"Error while creating destination directory '{DestinationDirectoryWithMacrosExtended}': {ex.Message}";
+                                userResultMessage = $"Destination directory '{DestinationDirectoryWithMacrosExtended}' was not found.";
                                 return FormFailedFileTransferResult(userResultMessage);
                             }
                         }
-                        else
+
+                        _batchContext.DestinationFiles = GetDestinationFiles(DestinationDirectoryWithMacrosExtended, cancellationToken);
+
+                        foreach (var file in files)
                         {
-                            userResultMessage = $"Destination directory '{DestinationDirectoryWithMacrosExtended}' was not found.";
-                            return FormFailedFileTransferResult(userResultMessage);
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            // Check that the connection is alive and if not try to connect again
+                            if (!client.IsConnected)
+                                await client.ConnectAsync(cancellationToken);
+
+                            var singleTransfer = new SingleFileTransfer(file, _batchContext, client, _renamingPolicy, _logger);
+                            var result = await singleTransfer.TransferSingleFile(cancellationToken);
+                            Result.Add(result);
                         }
                     }
-
-                    _batchContext.DestinationFiles = GetDestinationFiles(DestinationDirectoryWithMacrosExtended, _cancellationToken);
-
-                    foreach (var file in files)
-                    {
-                        _cancellationToken.ThrowIfCancellationRequested();
-
-                        // Check that the connection is alive and if not try to connect again
-                        if (!client.IsConnected)
-                            client.Connect();
-
-                        var singleTransfer = new SingleFileTransfer(file, _batchContext, client, _renamingPolicy, _logger);
-                        var result = singleTransfer.TransferSingleFile();
-                        _result.Add(result);
-                    }
-                    client.Disconnect();
+                } finally
+                {
+                    if (client != null)
+                        client.Disconnect();
+                        client.Dispose();
                 }
             }
         }
@@ -216,17 +223,18 @@ internal class FileTransporter
         }
         finally
         {
+            
             CleanTempFiles(_batchContext);
         }
 
-        return FormResultFromSingleTransferResults(_result);
+        return FormResultFromSingleTransferResults(Result);
     }
 
     #region Helper methods
     private ConnectionInfo GetConnectionInfo(Destination destination, Connection connect)
     {
         ConnectionInfo connectionInfo;
-        List<AuthenticationMethod> methods = new List<AuthenticationMethod>();
+        var methods = new List<AuthenticationMethod>();
 
         if (connect.UseKeyboardInteractiveAuthentication)
         {
@@ -300,8 +308,6 @@ internal class FileTransporter
             _logger.NotifyInformation(_batchContext, $"Keyboard-Interactive negotiation started with the server {_batchContext.Connection.Address}.");
             foreach (var serverPrompt in e.Prompts)
             {
-                _cancellationToken.ThrowIfCancellationRequested();
-
                 _logger.NotifyInformation(_batchContext, $"Prompt: {serverPrompt.Request.Replace(":", "")}");
 
                 if (!string.IsNullOrEmpty(_batchContext.Connection.Password) && serverPrompt.Request.IndexOf("Password:", StringComparison.InvariantCultureIgnoreCase) != -1)
@@ -316,7 +322,6 @@ internal class FileTransporter
 
                     foreach (var prompt in _batchContext.Connection.PromptAndResponse)
                     {
-                        _cancellationToken.ThrowIfCancellationRequested();
                         if (serverPrompt.Request.IndexOf(prompt.Prompt, StringComparison.InvariantCultureIgnoreCase) != -1)
                             serverPrompt.Response = prompt.Response;
                     }
@@ -469,7 +474,7 @@ internal class FileTransporter
 
             if (file.Name.Equals(source.FileName) || Util.FileMatchesMask(Path.GetFileName(file.FullName), source.FileName))
             {
-                FileItem item = new FileItem(file);
+                var item = new FileItem(file);
                 _logger.NotifyInformation(_batchContext, $"FILE LIST {item.FullPath}");
                 fileItems.Add(item);
             }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/RenamingPolicy.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/RenamingPolicy.cs
@@ -167,7 +167,7 @@ internal class RenamingPolicy
         return new Dictionary<string, Func<string, string>>
             {
                 {"%SourceFileName%", Path.GetFileNameWithoutExtension},
-                {"%SourceFileExtension%", (originalFile) => Path.HasExtension(originalFile) ? Path.GetExtension(originalFile) : String.Empty},
+                {"%SourceFileExtension%", (originalFile) => Path.HasExtension(originalFile) ? Path.GetExtension(originalFile) : string.Empty},
             };
     }
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Result.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Result.cs
@@ -46,7 +46,7 @@ public class Result
     /// ]
     /// </code>
     /// </example>
-    public IEnumerable<string> TransferredFileNames { get; private set; }
+    public string[] TransferredFileNames { get; private set; }
 
     /// <summary>
     /// Dictionary of file names and errors messages of the failed transfers.
@@ -82,7 +82,7 @@ public class Result
     /// ]
     /// </code>
     /// </example>
-    public IEnumerable<string> TransferredFilePaths { get; private set; }
+    public string[] TransferredFilePaths { get; private set; }
 
     /// <summary>
     /// List of destination file paths of the transferred files.
@@ -93,7 +93,7 @@ public class Result
     ///     "C:\\test\\test2.txt"
     /// ]
     /// </example>
-    public IEnumerable<string> TransferredDestinationFilePaths { get; private set; }
+    public string[] TransferredDestinationFilePaths { get; private set; }
 
     /// <summary>
     /// Operations logs for the transfer.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Result.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Result.cs
@@ -46,7 +46,7 @@ public class Result
     /// ]
     /// </code>
     /// </example>
-    public string[] TransferredFileNames { get; private set; }
+    public IEnumerable<string> TransferredFileNames { get; private set; }
 
     /// <summary>
     /// Dictionary of file names and errors messages of the failed transfers.
@@ -82,7 +82,7 @@ public class Result
     /// ]
     /// </code>
     /// </example>
-    public string[] TransferredFilePaths { get; private set; }
+    public IEnumerable<string> TransferredFilePaths { get; private set; }
 
     /// <summary>
     /// List of destination file paths of the transferred files.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/TimeoutAction.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/TimeoutAction.cs
@@ -1,0 +1,55 @@
+﻿namespace Frends.SFTP.DownloadFiles.Definitions
+{
+    internal class TimeoutAction
+    {
+        private Thread ActionThread { get; set; }
+        private Thread TimeoutThread { get; set; }
+        private AutoResetEvent ThreadSynchronizer { get; set; }
+        private bool _success;
+        private bool _timout;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="waitLimit">in ms</param>
+        /// <param name="action">delegate action</param>
+        public TimeoutAction(int waitLimit, Action action)
+        {
+            ThreadSynchronizer = new AutoResetEvent(false);
+            ActionThread = new Thread(new ThreadStart(delegate
+            {
+                action.Invoke();
+                if (_timout) return;
+                _timout = true;
+                _success = true;
+                ThreadSynchronizer.Set();
+            }));
+
+            TimeoutThread = new Thread(new ThreadStart(delegate
+            {
+                Thread.Sleep(waitLimit * 1000);
+                if (_success) return;
+                _timout = true;
+                _success = false;
+                ThreadSynchronizer.Set();
+            }));
+        }
+
+        /// <summary>
+        /// If the action takes longer than the wait limit, this will throw a TimeoutException
+        /// </summary>
+        public void Start()
+        {
+            ActionThread.Start();
+            TimeoutThread.Start();
+
+            ThreadSynchronizer.WaitOne();
+
+            if (!_success)
+            {
+                throw new TimeoutException();
+            }
+            ThreadSynchronizer.Close();
+        }
+    }
+}

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.cs
@@ -92,7 +92,7 @@ public class SFTP
     /// <param name="options">Transfer options</param>
     /// <param name="cancellationToken">CancellationToken is given by Frends</param>
     /// <returns>Result object {bool ActionSkiped, bool Success, string UserResultMessage, int SuccessfulTransferCount, int FailedTransferCount, IEnumrable TransferredFileNames [ string TransferredFileName ], Dictionary TransferErrors { string FileName: [ string TransferError ] }, IEnumerable TransferredFilePaths [ string FilePath ], IEnumerable TransferredDestinationFilePaths [ string FilePath ], IDictionary Operationslog { string TimeStamp, string Operation }} </returns>
-    public static Result DownloadFiles(
+    public static async Task<Result> DownloadFiles(
         [PropertyTab] Source source,
         [PropertyTab] Destination destination,
         [PropertyTab] Connection connection,
@@ -117,8 +117,7 @@ public class SFTP
             if (string.IsNullOrEmpty(info.ProcessUri))
                 fileTransferLog.Warning("ProcessUri is empty. This means the transfer view cannot link to the correct page.");
 
-            Guid executionId;
-            if (!Guid.TryParse(info.TaskExecutionID, out executionId))
+            if (!Guid.TryParse(info.TaskExecutionID, out Guid executionId))
             {
                 fileTransferLog.Warning("'{0}' is not a valid task execution ID, will default to random Guid.", info.TaskExecutionID);
                 executionId = Guid.NewGuid();
@@ -140,8 +139,8 @@ public class SFTP
                 Connection = connection
             };
 
-            var fileTransporter = new FileTransporter(logger, _batchContext, executionId, cancellationToken);
-            var result = fileTransporter.Run();
+            var fileTransporter = new FileTransporter(logger, _batchContext, executionId);
+            var result = await fileTransporter.Run(cancellationToken);
 
             if (options.ThrowErrorOnFail && !result.Success)
                 throw new Exception($"SFTP transfer failed: {result.UserResultMessage}. " +
@@ -182,7 +181,6 @@ public class SFTP
         try
         {
             return string.Join("\n", buffer.Select(x => x.Item1 == DateTimeOffset.MinValue ? "..." : $"{x.Item1:HH:mm:ssZ}: {x.Item2}"));
-
         }
         catch (Exception e)
         {

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.7.6</Version>
+	  <Version>2.7.8</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.7.1</Version>
+	  <Version>2.7.6</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>
@@ -35,7 +35,7 @@
 	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 	<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	<PackageReference Include="Serilog" Version="2.11.0" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="SSH.NET" Version="2023.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
 	<PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
#168 
- Changed SftpClient operations to use async methods with CancellationToken.
- Added FileOperations class which handles file operations as async with CancellationToken e.g. Append, Copy, Move.
- Fixed issue where the Task gets stuck and can't be terminated.

#169
- [Breaking] Changed TransferredDestinationFilePaths Result property type from List to string[].