### PR TITLE
SFTP.DownloadFiles - FileNameEncoding and related parameters moved

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.0] - 2024-08-16
+### Fixed
+- [Breaking] Moved the FileNameEncoding, FileNameEncodingInString and EnableBomForFileName parameters from destination tab to connection.
+
 ## [2.11.0] - 2024-04-30
 ### Fixed
 - Fixed issue were Task threw exception when using macros in Source Directory.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/AppendTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/AppendTests.cs
@@ -21,8 +21,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             {
                 Directory = _destWorkDir,
                 FileName = _source.FileName,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Append,
                 AddNewLine = true,
                 FileContentEncoding = FileEncoding.UTF8,
@@ -62,8 +60,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Append,
                 AddNewLine = true,
                 FileContentEncoding = FileEncoding.UTF8,
@@ -100,13 +96,12 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Append,
                 AddNewLine = true,
                 FileContentEncoding = FileEncoding.UTF8,
                 EnableBomForContent = true
             };
+
             var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content1 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
@@ -136,13 +131,12 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Append,
                 AddNewLine = true,
                 FileContentEncoding = FileEncoding.UTF8,
                 EnableBomForContent = true
             };
+
             var result = await SFTP.DownloadFiles(_source, destination, _connection, options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             var content1 = File.ReadAllText(Path.Combine(destination.Directory, _source.FileName));
@@ -173,8 +167,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Append,
                 AddNewLine = true,
                 FileContentEncoding = FileEncoding.UTF8,
@@ -211,8 +203,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Append,
                 AddNewLine = true,
                 FileContentEncoding = FileEncoding.UTF8,
@@ -257,8 +247,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Append,
                 AddNewLine = false,
                 FileContentEncoding = FileEncoding.UTF8,
@@ -286,5 +274,3 @@ namespace Frends.SFTP.DownloadFiles.Tests
         }
     }
 }
-
-

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ConnectivityTests.cs
@@ -108,9 +108,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = Path.Combine(_workDir, "destination"),
-                Action = DestinationAction.Overwrite,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true
+                Action = DestinationAction.Overwrite
             };
 
             result = await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken());

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/EncodingTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/EncodingTests.cs
@@ -20,11 +20,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
         {
             var destination = new Destination
             {
-                Directory = _destination.Directory,
-                FileNameEncoding = FileEncoding.ANSI
+                Directory = _destination.Directory
             };
 
-            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var connection = Helpers.GetSftpConnection();
+            connection.FileNameEncoding = FileEncoding.ANSI;
+
+            var result = await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
             Assert.IsTrue(File.Exists(Path.Combine(_destination.Directory, _source.FileName)));
@@ -35,11 +37,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
         {
             var destination = new Destination
             {
-                Directory = _destination.Directory,
-                FileNameEncoding = FileEncoding.ASCII
+                Directory = _destination.Directory
             };
 
-            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var connection = Helpers.GetSftpConnection();
+            connection.FileNameEncoding = FileEncoding.ASCII;
+
+            var result = await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
             Assert.IsTrue(File.Exists(Path.Combine(_destination.Directory, _source.FileName)));
@@ -50,12 +54,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
         {
             var destination = new Destination
             {
-                Directory = _destination.Directory,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = false
+                Directory = _destination.Directory
             };
 
-            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var connection = Helpers.GetSftpConnection();
+            connection.EnableBomForFileName = false;
+
+            var result = await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
             Assert.IsTrue(File.Exists(Path.Combine(_destination.Directory, _source.FileName)));
@@ -67,8 +72,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destination.Directory,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true
             };
 
             var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
@@ -82,11 +85,13 @@ namespace Frends.SFTP.DownloadFiles.Tests
         {
             var destination = new Destination
             {
-                Directory = _destination.Directory,
-                FileNameEncoding = FileEncoding.WINDOWS1252
+                Directory = _destination.Directory
             };
 
-            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var connection = Helpers.GetSftpConnection();
+            connection.FileNameEncoding = FileEncoding.WINDOWS1252;
+
+            var result = await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
             Assert.IsTrue(File.Exists(Path.Combine(_destination.Directory, _source.FileName)));
@@ -97,12 +102,14 @@ namespace Frends.SFTP.DownloadFiles.Tests
         {
             var destination = new Destination
             {
-                Directory = _destination.Directory,
-                FileNameEncoding = FileEncoding.Other,
-                FileNameEncodingInString = "windows-1252"
+                Directory = _destination.Directory
             };
 
-            var result = await SFTP.DownloadFiles(_source, destination, _connection, _options, _info, new CancellationToken());
+            var connection = Helpers.GetSftpConnection();
+            connection.FileNameEncoding = FileEncoding.Other;
+            connection.FileNameEncodingInString = "windows-1252";
+
+            var result = await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken());
             Assert.IsTrue(result.Success);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
             Assert.IsTrue(File.Exists(Path.Combine(_destination.Directory, _source.FileName)));

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ErrorTests.cs
@@ -100,9 +100,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
-                Action = DestinationAction.Error,
+                Action = DestinationAction.Error
             };
 
             var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken()));
@@ -129,9 +127,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
-                Action = DestinationAction.Error,
+                Action = DestinationAction.Error
             };
 
             var ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken()));

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/DownloadFilesTestBase.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/DownloadFilesTestBase.cs
@@ -36,9 +36,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             _destination = new Destination
             {
                 Directory = Path.Combine(_workDir, "destination"),
-                Action = DestinationAction.Error,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true
+                Action = DestinationAction.Error
             };
 
             _options = new Options

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/Lib/Helpers.cs
@@ -58,6 +58,8 @@ namespace Frends.SFTP.DownloadFiles.Tests
                 UserName = _dockerUser,
                 Authentication = AuthenticationType.UsernamePassword,
                 Password = _dockerPwd,
+                FileNameEncoding = FileEncoding.UTF8,
+                EnableBomForFileName = true,
                 BufferSize = 32,
                 KeepAliveInterval = -1,
                 PrivateKeyPassphrase = _dockerPass,

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/MacroTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/MacroTests.cs
@@ -57,8 +57,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             {
                 Directory = Path.Combine(_destWorkDir, "test%Year%"),
                 FileName = "",
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Error,
             };
 
@@ -153,17 +151,19 @@ namespace Frends.SFTP.DownloadFiles.Tests
             {
                 Directory = Path.Combine(_destination.Directory, "%Guid%"),
                 FileName = "",
-                FileNameEncoding = FileEncoding.ANSI,
                 Action = DestinationAction.Overwrite,
                 FileContentEncoding = FileEncoding.ANSI,
             };
+
+            var connection = Helpers.GetSftpConnection();
+            connection.FileNameEncoding = FileEncoding.ANSI;
 
             Helpers.UploadTestFiles("/upload/Upload", 1, null, new List<string> { "test1.txt" });
 
             for (var i = 0; i <= 10; i++)
             {
                 Console.WriteLine($"Iteration: {i}");
-                var result = await SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken());
+                var result = await SFTP.DownloadFiles(source, destination, connection, _options, _info, new CancellationToken());
                 Assert.IsTrue(result.Success);
                 Assert.AreEqual(1, result.SuccessfulTransferCount);
             }
@@ -185,17 +185,19 @@ namespace Frends.SFTP.DownloadFiles.Tests
             {
                 Directory = Path.Combine(_destination.Directory, "%DateTime%"),
                 FileName = "",
-                FileNameEncoding = FileEncoding.ANSI,
                 Action = DestinationAction.Overwrite,
                 FileContentEncoding = FileEncoding.ANSI,
             };
+
+            var connection = Helpers.GetSftpConnection();
+            connection.FileNameEncoding = FileEncoding.ANSI;
 
             Helpers.UploadTestFiles("/upload/Upload", 10, null, new List<string> { "test.txt" });
 
             for (var i = 0; i <= 10; i++)
             {
                 Console.WriteLine($"Iteration: {i}");
-                var result = await SFTP.DownloadFiles(source, destination, _connection, _options, _info, new CancellationToken());
+                var result = await SFTP.DownloadFiles(source, destination, connection, _options, _info, new CancellationToken());
                 Assert.IsTrue(result.Success);
                 Assert.AreEqual(1, result.SuccessfulTransferCount);
             }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/PreserveModifiedTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/PreserveModifiedTests.cs
@@ -22,9 +22,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             destination = new Destination
             {
                 Directory = Path.Combine(_workDir, "destination"),
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
-                Action = DestinationAction.Overwrite,
+                Action = DestinationAction.Overwrite
             };
 
             options = new Options

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ServerFingerprintTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/ServerFingerprintTests.cs
@@ -178,9 +178,7 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = Path.Combine(_workDir, "destination"),
-                Action = DestinationAction.Overwrite,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true
+                Action = DestinationAction.Overwrite
             };
 
             ex = Assert.ThrowsAsync<Exception>(async () => await SFTP.DownloadFiles(_source, destination, connection, _options, _info, new CancellationToken()));

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.Tests/TransferTests.cs
@@ -94,8 +94,6 @@ namespace Frends.SFTP.DownloadFiles.Tests
             var destination = new Destination
             {
                 Directory = _destWorkDir,
-                FileNameEncoding = FileEncoding.UTF8,
-                EnableBomForFileName = true,
                 Action = DestinationAction.Error,
             };
 

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Connection.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Connection.cs
@@ -99,6 +99,29 @@ public class Connection
     [DisplayFormat(DataFormatString = "Text")]
     public string PrivateKeyPassphrase { get; set; }
 
+     /// <summary>
+    /// If set, this encoding will be used to encode and decode command
+    /// parameters and server responses, such as file names.
+    /// By selecting 'Other' you can use any encoding.
+    /// </summary>
+    /// <example>FileEncoding.ANSI</example>
+    [DefaultValue(FileEncoding.ANSI)]
+    public FileEncoding FileNameEncoding { get; set; }
+
+    /// <summary>
+    /// Additional option for UTF-8 encoding to enable bom.
+    /// </summary>
+    /// <example>true</example>
+    [UIHint(nameof(FileNameEncoding), "", FileEncoding.UTF8)]
+    public bool EnableBomForFileName { get; set; }
+
+    /// <summary>
+    /// File encoding to be used. A partial list of possible encodings: https://en.wikipedia.org/wiki/Windows_code_page#List.
+    /// </summary>
+    /// <example>utf-8</example>
+    [UIHint(nameof(FileNameEncoding), "", FileEncoding.Other)]
+    public string FileNameEncodingInString { get; set; }
+
     /// <summary>
     /// Fingerprint of the SFTP server. When using "Username-Password"
     /// authentication it is recommended to use server fingerprint in

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Destination.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/Destination.cs
@@ -25,29 +25,6 @@ public class Destination
     public string FileName { get; set; }
 
     /// <summary>
-    /// If set, this ecoding will be used to encode and decode command
-    /// parameters and server responses, such as file names.
-    /// By selecting 'Other' you can use any encoding.
-    /// </summary>
-    /// <example>FileEncoding.ANSI</example>
-    [DefaultValue(FileEncoding.ANSI)]
-    public FileEncoding FileNameEncoding { get; set; }
-
-    /// <summary>
-    /// Additional option for UTF-8 encoding to enable bom.
-    /// </summary>
-    /// <example>true</example>
-    [UIHint(nameof(FileNameEncoding), "", FileEncoding.UTF8)]
-    public bool EnableBomForFileName { get; set; }
-
-    /// <summary>
-    /// File encoding to be used. A partial list of possible encodings: https://en.wikipedia.org/wiki/Windows_code_page#List.
-    /// </summary>
-    /// <example>utf-8</example>
-    [UIHint(nameof(FileNameEncoding), "", FileEncoding.Other)]
-    public string FileNameEncodingInString { get; set; }
-
-    /// <summary>
     /// Operation to determine what to do if destination file exists.
     /// </summary>
     /// <example>DestinationAction.Error</example>

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -408,7 +408,7 @@ internal class FileTransporter
 
         connectionInfo = new ConnectionInfo(connect.Address, connect.Port, connect.UserName, methods.ToArray())
         {
-            Encoding = Util.GetEncoding(destination.FileNameEncoding, destination.FileNameEncodingInString, destination.EnableBomForFileName),
+            Encoding = Util.GetEncoding(connect.FileNameEncoding, connect.FileNameEncodingInString, connect.EnableBomForFileName),
             ChannelCloseTimeout = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout),
             Timeout = TimeSpan.FromSeconds(_batchContext.Connection.ConnectionTimeout),
         };

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.11.0</Version>
+	  <Version>3.0.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
Closes #204 . FileNameEncoding, EnableBomForFileName and FileNameEncodingInString have been moved from Destination-tab to Connection-tab. This is a breaking change, so major version number has been bumped to 3.0.0.