### PR TITLE
SFTP.DownloadFiles - Memory leak fix

### DIFF
--- a/Frends.SFTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.SFTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.14.0] - 2024-09-30
+### Fixed
+- Fixed small memory leak with CancellationTokenSource by adding dispose to the end of the Task.
+
 ## [2.13.0] - 2024-09-05
 ### Fixed
 - Fixed issue with certain SFTP servers which did not use IsRegularFile property on files by modifying the logic to check that the file is not anything else than a regular file.

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.cs
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.cs
@@ -173,7 +173,7 @@ public class SFTP
         }
         finally
         {
-            if (options.Timeout > 0)
+            if (linkedCts != null)
                 linkedCts.Dispose();
         }
     }

--- a/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
+++ b/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles/Frends.SFTP.DownloadFiles.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.SFTP.DownloadFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.DownloadFiles</RootNamespace>
 
-	  <Version>2.13.0</Version>
+	  <Version>2.14.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#215 

## [2.14.0] - 2024-09-30
### Fixed
- Fixed small memory leak with CancellationTokenSource by adding dispose to the end of the Task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new parameters for file operations, including options to include subdirectories and set operation timeouts.
	- Added async methods with cancellation tokens for improved file operation handling.

- **Bug Fixes**
	- Resolved memory leak issues related to cancellation token handling.
	- Improved compatibility with certain SFTP servers by refining file identification logic.

- **Enhancements**
	- Enhanced error handling and logging mechanisms.
	- Updated the Renci.SshNet library to improve functionality and performance.

- **Version Updates**
	- Updated project version to 2.14.0 and SSH.NET package to version 2024.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->