### PR TITLE
SFTP.ListFiles - Fixed issue with thread safety

### DIFF
--- a/Frends.SFTP.ListFiles/CHANGELOG.md
+++ b/Frends.SFTP.ListFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.4.0] - 2025-01-03
+### Fixed
+- Fixed issue with COnnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.
+
 ## [2.3.0] - 2024-08-19
 ### Updated
 - Updated Renci.SshNet library to version 2024.1.0.

--- a/Frends.SFTP.ListFiles/CHANGELOG.md
+++ b/Frends.SFTP.ListFiles/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.4.0] - 2025-01-03
 ### Fixed
-- Fixed issue with COnnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.
+- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.
 
 ## [2.3.0] - 2024-08-19
 ### Updated

--- a/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles/Definitions/ConnectionInfoBuilder.cs
+++ b/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles/Definitions/ConnectionInfoBuilder.cs
@@ -7,8 +7,8 @@ namespace Frends.SFTP.ListFiles.Definitions;
 
 internal class ConnectionInfoBuilder
 {
-    private static Input _input;
-    private static Connection _connection;
+    private Input _input;
+    private Connection _connection;
 
     internal ConnectionInfoBuilder(Input input, Connection connect)
     {

--- a/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles.csproj
+++ b/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.SFTP.ListFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.ListFiles</RootNamespace>
 
-	  <Version>2.3.0</Version>
+	  <Version>2.4.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#219 

## [2.4.0] - 2025-01-03
### Fixed
- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved a thread-safety issue in the `ConnectionInfoBuilder` by removing static properties
	- Ensured connection and input parameters are now instance-specific

- **Chores**
	- Updated project version from 2.3.0 to 2.4.0
	- Updated changelog with version details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->