### PR TITLE
SFTP.MoveFile - Fixed issue with ConnectionInfoBuilder static properties

### DIFF
--- a/Frends.SFTP.MoveFile/CHANGELOG.md
+++ b/Frends.SFTP.MoveFile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2025-01-10
+### Fixed
+- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.
+
 ## [1.2.0] - 2024-08-19
 ### Updated
 - Updated Renci.SshNet library to version 2024.1.0.

--- a/Frends.SFTP.MoveFile/Frends.SFTP.MoveFile/Definitions/ConnectionInfoBuilder.cs
+++ b/Frends.SFTP.MoveFile/Frends.SFTP.MoveFile/Definitions/ConnectionInfoBuilder.cs
@@ -7,8 +7,8 @@ namespace Frends.SFTP.MoveFile.Definitions;
 
 internal class ConnectionInfoBuilder
 {
-    private static Connection _connection;
-    private static Input _input;
+    private Connection _connection;
+    private Input _input;
 
     internal ConnectionInfoBuilder(Connection connect, Input input)
     {

--- a/Frends.SFTP.MoveFile/Frends.SFTP.MoveFile/Frends.SFTP.MoveFile.csproj
+++ b/Frends.SFTP.MoveFile/Frends.SFTP.MoveFile/Frends.SFTP.MoveFile.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.SFTP.MoveFile</AssemblyName>
 	  <RootNamespace>Frends.SFTP.MoveFile</RootNamespace>
 
-	  <Version>1.2.0</Version>
+	  <Version>1.3.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#219 

## [1.3.0] - 2025-01-10
### Fixed
- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved thread safety issue in `ConnectionInfoBuilder` by changing static fields to instance variables.

- **Chores**
	- Updated project version from 1.2.0 to 1.3.0.
	- Updated changelog with version 1.3.0 details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->