### PR TITLE
SFTP.ReadFile - Fixed issue with ConnectionInfoBuilder static fields

### DIFF
--- a/Frends.SFTP.ReadFile/CHANGELOG.md
+++ b/Frends.SFTP.ReadFile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.3.0] - 2025-01-10
+### Fixed
+- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.
+
 ## [2.2.0] - 2024-08-19
 ### Updated
 - Updated Renci.SshNet library to version 2024.1.0.

--- a/Frends.SFTP.ReadFile/Frends.SFTP.ReadFile/Definitions/ConnectionInfoBuilder.cs
+++ b/Frends.SFTP.ReadFile/Frends.SFTP.ReadFile/Definitions/ConnectionInfoBuilder.cs
@@ -7,8 +7,8 @@ namespace Frends.SFTP.ReadFile.Definitions;
 
 internal class ConnectionInfoBuilder
 {
-    private static Input _input;
-    private static Connection _connection;
+    private Input _input;
+    private Connection _connection;
 
     internal ConnectionInfoBuilder(Input input, Connection connect)
     {

--- a/Frends.SFTP.ReadFile/Frends.SFTP.ReadFile/Frends.SFTP.ReadFile.csproj
+++ b/Frends.SFTP.ReadFile/Frends.SFTP.ReadFile/Frends.SFTP.ReadFile.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.SFTP.ReadFile</AssemblyName>
 	  <RootNamespace>Frends.SFTP.ReadFile</RootNamespace>
 
-	  <Version>2.2.0</Version>
+	  <Version>2.3.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#219 

## [2.3.0] - 2025-01-10
### Fixed
- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved a thread-safety issue in the `ConnectionInfoBuilder` by changing static fields to instance-specific fields.

- **Chores**
	- Updated project version from 2.2.0 to 2.3.0
	- Updated changelog with version 2.3.0 details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->