### PR TITLE
SFTP.RenameFile - Fixed issue with ConnectionInfoBuilder static fields

### DIFF
--- a/Frends.SFTP.RenameFile/CHANGELOG.md
+++ b/Frends.SFTP.RenameFile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.0] - 2025-01-10
+### Fixed
+- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.
+
 ## [2.1.0] - 2024-08-19
 ### Updated
 - Updated Renci.SshNet library to version 2024.1.0.

--- a/Frends.SFTP.RenameFile/Frends.SFTP.RenameFile/Definitions/ConnectionInfoBuilder.cs
+++ b/Frends.SFTP.RenameFile/Frends.SFTP.RenameFile/Definitions/ConnectionInfoBuilder.cs
@@ -7,8 +7,8 @@ namespace Frends.SFTP.RenameFile.Definitions;
 
 internal class ConnectionInfoBuilder
 {
-    private static Connection _connection;
-    private static CancellationToken _cancellationToken;
+    private Connection _connection;
+    private CancellationToken _cancellationToken;
 
     internal ConnectionInfoBuilder(Connection connect, CancellationToken cancellationToken)
     {

--- a/Frends.SFTP.RenameFile/Frends.SFTP.RenameFile/Frends.SFTP.RenameFile.csproj
+++ b/Frends.SFTP.RenameFile/Frends.SFTP.RenameFile/Frends.SFTP.RenameFile.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.SFTP.RenameFile</AssemblyName>
 	  <RootNamespace>Frends.SFTP.RenameFile</RootNamespace>
 
-	  <Version>2.1.0</Version>
+	  <Version>2.2.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#219 

## [2.2.0] - 2025-01-10
### Fixed
- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.