### PR TITLE
SFTP.DeleteFiles - Fixed issue with ConnectionInfoBuilder static fields

### DIFF
--- a/Frends.SFTP.DeleteFiles/CHANGELOG.md
+++ b/Frends.SFTP.DeleteFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.0] - 2025-01-13
+### Fixed
+- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.
+
 ## [2.1.0] - 2024-08-19
 ### Updated
 - Updated Renci.SshNet library to version 2024.1.0.

--- a/Frends.SFTP.DeleteFiles/Frends.SFTP.DeleteFiles/Definitions/ConnectionInfoBuilder.cs
+++ b/Frends.SFTP.DeleteFiles/Frends.SFTP.DeleteFiles/Definitions/ConnectionInfoBuilder.cs
@@ -12,9 +12,9 @@ using Frends.SFTP.DeleteFiles.Enums;
 
 internal class ConnectionInfoBuilder
 {
-    private static Input _input;
-    private static Connection _connection;
-    private static CancellationToken _cancellationToken;
+    private Input _input;
+    private Connection _connection;
+    private CancellationToken _cancellationToken;
 
     internal ConnectionInfoBuilder(Input input, Connection connect, CancellationToken cancellationToken)
     {

--- a/Frends.SFTP.DeleteFiles/Frends.SFTP.DeleteFiles/Frends.SFTP.DeleteFiles.csproj
+++ b/Frends.SFTP.DeleteFiles/Frends.SFTP.DeleteFiles/Frends.SFTP.DeleteFiles.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	  <TargetFramework>net6.0</TargetFramework>
 	  <LangVersion>Latest</LangVersion>
-	  <Version>2.1.0</Version>
+	  <Version>2.2.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>

--- a/Frends.SFTP.DeleteFiles/Frends.SFTP.DeleteFiles/GlobalSuppressions.cs
+++ b/Frends.SFTP.DeleteFiles/Frends.SFTP.DeleteFiles/GlobalSuppressions.cs
@@ -6,3 +6,5 @@
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1629:Documentation text should end with a period", Justification = "No need", Scope = "namespaceanddescendants", Target = "~N:Frends.SFTP.DeleteFiles")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "No need", Scope = "type", Target = "~T:Frends.SFTP.DeleteFiles.Definitions.ConnectionInfoBuilder")]
 [assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1519:Braces should not be omitted from multi-line child statement", Justification = "Following Frends guidelines", Scope = "namespaceanddescendants", Target = "~N:Frends.SFTP.DeleteFiles")]
+[assembly: SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "No need", Scope = "namespaceanddescendants", Target = "~N:Frends.SFTP.DeleteFiles")]
+[assembly: SuppressMessage("Major Code Smell", "S2933:Fields that are only assigned in the constructor should be \"readonly\"", Justification = "No need", Scope = "namespaceanddescendants", Target = "~N:Frends.SFTP.DeleteFiles")]


### PR DESCRIPTION
#219 

## [2.2.0] - 2025-01-13
### Fixed
- Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved thread safety issue in `ConnectionInfoBuilder` by converting static fields to instance fields.

- **Chores**
	- Updated project version from 2.1.0 to 2.2.0.
	- Added code suppression messages for style and code smell warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->