### PR TITLE
Update documentation regarding encoding

### DIFF
--- a/Frends.SFTP.ListFiles/CHANGELOG.md
+++ b/Frends.SFTP.ListFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.5.0] - 2025-04-09
+### Changed
+- Clarified that the encoding parameter is used for the file name encoding.
+
 ## [2.4.0] - 2025-01-03
 ### Fixed
 - Fixed issue with ConnectionInfoBuilder having static properties for connection and input paramaters which lead to Task not being thread safe.

--- a/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles/Definitions/Input.cs
+++ b/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles/Definitions/Input.cs
@@ -38,7 +38,7 @@ public class Input
     public bool IncludeSubdirectories { get; set; }
 
     /// <summary>
-    /// Encoding for the read content.
+    /// Encoding for the file names.
     /// By selecting 'Other' you can use any encoding.
     /// </summary>
     /// <example>FileEncoding.ANSI</example>

--- a/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles.csproj
+++ b/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles/Frends.SFTP.ListFiles.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.SFTP.ListFiles</AssemblyName>
 	  <RootNamespace>Frends.SFTP.ListFiles</RootNamespace>
 
-	  <Version>2.4.0</Version>
+	  <Version>2.5.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
Updated documentation to mention that encoding is used for file names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the file encoding parameter now specifically applies to file names.
  - Updated explanatory notes to improve understanding of the encoding configuration.

- **Chores**
  - Upgraded the software version from 2.4.0 to 2.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->